### PR TITLE
Make text smaller for new merge request event

### DIFF
--- a/server/webhook/merge_request.go
+++ b/server/webhook/merge_request.go
@@ -68,7 +68,7 @@ func (w *webhook) handleChannelMergeRequest(event *gitlab.MergeEvent) ([]*Handle
 	message := ""
 
 	if pr.Action == "open" {
-		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n# new merge-request by [%s](%s) on [%s](%s)\n\n%s", pr.Title, repo.PathWithNamespace, pr.IID, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), pr.CreatedAt, pr.URL, pr.Description)
+		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s) new merge-request by [%s](%s) on [%s](%s)\n\n%s", pr.Title, repo.PathWithNamespace, pr.IID, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), pr.CreatedAt, pr.URL, pr.Description)
 	} else if pr.Action == "merge" {
 		message = fmt.Sprintf("[%s] Merge request [#%v %s](%s) was merged by [%s](%s)", repo.PathWithNamespace, pr.IID, pr.Title, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
 	} else if pr.Action == "close" {


### PR DESCRIPTION
## Background

Seemed like a bug, but may have been intended to have the text really large to grab someone's attention. I adjusted it to make it a little less noisy, but feel free to tweak how you'd like it.

### Before
<img width="1184" alt="Screen Shot 2019-06-14 at 4 24 31 PM" src="https://user-images.githubusercontent.com/16150/59516118-eb0eee00-8ec0-11e9-8adb-4210adec4c30.png">

### After
<img width="1184" alt="Screen Shot 2019-06-14 at 4 25 22 PM" src="https://user-images.githubusercontent.com/16150/59516169-0843bc80-8ec1-11e9-9e46-bf2b978286c9.png">
