### PR TITLE
Link to root URL with button

### DIFF
--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
@@ -120,7 +120,7 @@ export default class SidebarButtons extends React.PureComponent {
             <div style={container}>
                 <a
                     key='gitlabHeader'
-                    href={baseURL + '/oauth/applications/'}
+                    href={baseURL}
                     target='_blank'
                     rel='noopener noreferrer'
                     style={button}


### PR DESCRIPTION
There is no value in linking to the `/oauth/applications/` page, once the user is connected.