### PR TITLE
decrease size of new issue messages

### DIFF
--- a/server/webhook/issue.go
+++ b/server/webhook/issue.go
@@ -68,11 +68,11 @@ func (w *webhook) handleChannelIssue(event *gitlab.IssueEvent) ([]*HandleWebhook
 	message := ""
 
 	if issue.Action == "open" {
-		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n# new issue by [%s](%s) on [%s](%s)\n\n%s", issue.Title, repo.PathWithNamespace, issue.IID, issue.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), issue.CreatedAt, issue.URL, issue.Description)
+		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n## new issue by [%s](%s) on [%s](%s)\n\n%s", issue.Title, repo.PathWithNamespace, issue.IID, issue.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), issue.CreatedAt, issue.URL, issue.Description)
 	} else if issue.Action == "close" {
 		message = fmt.Sprintf("[%s] Issue [%s](%s) closed by [%s](%s)", repo.PathWithNamespace, issue.Title, issue.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
 	} else if issue.Action == "update" && len(event.Changes.Labels.Current) > 0 && !sameLabels(event.Changes.Labels.Current, event.Changes.Labels.Previous) {
-		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n# issue labeled `%s` by [%s](%s) on [%s](%s)\n\n%s", issue.Title, repo.PathWithNamespace, issue.IID, issue.URL, labelToString(event.Changes.Labels.Current), event.User.Username, event.User.WebsiteURL, issue.UpdatedAt, issue.URL, issue.Description)
+		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n## issue labeled `%s` by [%s](%s) on [%s](%s)\n\n%s", issue.Title, repo.PathWithNamespace, issue.IID, issue.URL, labelToString(event.Changes.Labels.Current), event.User.Username, event.User.WebsiteURL, issue.UpdatedAt, issue.URL, issue.Description)
 	}
 
 	if len(message) > 0 {


### PR DESCRIPTION
The new issue notifications are way too big. IMO I'd even go with three `#`'s but two should be fine as well.