### PR TITLE
Fix trailing newline in markdown link for push webhook

### DIFF
--- a/server/webhook/push.go
+++ b/server/webhook/push.go
@@ -53,7 +53,7 @@ func (w *webhook) handleChannelPush(event *gitlab.PushEvent) ([]*HandleWebhook, 
 		message = fmt.Sprintf("[%s](%s) has pushed %d commits to [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.TotalCommitsCount, event.Project.PathWithNamespace, event.Project.WebURL)
 	}
 	for _, commit := range event.Commits {
-		message += fmt.Sprintf("\n- [%s](%s)", commit.Message, commit.URL)
+		message += fmt.Sprintf("\n%s[%s](%s)", commit.Message, "View Commit", commit.URL)
 	}
 
 	toChannels := make([]string, 0)

--- a/server/webhook/push_fixture_test.go
+++ b/server/webhook/push_fixture_test.go
@@ -34,7 +34,7 @@ const PushEvent = `{
 	},
 	"commits":[{
 		"id":"c30217b62542c586fdbadc7b5ee762bfdca10663",
-		"message":"really cool commit",
+		"message":"really cool commit\n",
 		"timestamp":"2019-04-17T20:22:03Z",
 		"url":"http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663",
 		"author":{
@@ -92,7 +92,7 @@ const pushEventWithTwoCommits = `{
 	},
 	"commits":[{
 		"id":"c30217b62542c586fdbadc7b5ee762bfdca10663",
-		"message":"really cool commit",
+		"message":"really cool commit\n",
 		"timestamp":"2019-04-17T20:22:03Z",
 		"url":"http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663",
 		"author":{
@@ -104,7 +104,7 @@ const pushEventWithTwoCommits = `{
 		"removed":[]
 	}, {
 		"id":"595f2a068cce60954565b224bc7c966c9e708cbf",
-		"message":"another cool commit",
+		"message":"another cool commit\n",
 		"timestamp":"2019-04-17T20:23:05Z",
 		"url":"http://localhost:3000/manland/webhook/commit/595f2a068cce60954565b224bc7c966c9e708cbf",
 		"author":{

--- a/server/webhook/push_test.go
+++ b/server/webhook/push_test.go
@@ -24,7 +24,7 @@ var testDataPush = []testDataPushStr{{
 		}),
 		res: []*HandleWebhook{{
 			Message: "[manland](http://my.gitlab.com/manland) has pushed 1 commit to [manland/webhook](http://localhost:3000/manland/webhook)\n" +
-				"- [really cool commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)",
+				"really cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)",
 			ToUsers:    []string{}, // No DM because user know he has push commits
 			ToChannels: []string{"channel1"},
 			From:       "manland",
@@ -37,8 +37,8 @@ var testDataPush = []testDataPushStr{{
 		}),
 		res: []*HandleWebhook{{
 			Message: "[manland](http://my.gitlab.com/manland) has pushed 2 commits to [manland/webhook](http://localhost:3000/manland/webhook)\n" +
-				"- [really cool commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)\n"+
-				"- [another cool commit](http://localhost:3000/manland/webhook/commit/595f2a068cce60954565b224bc7c966c9e708cbf)",
+				"really cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)\n"+
+				"another cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/595f2a068cce60954565b224bc7c966c9e708cbf)",
 			ToUsers:    []string{}, // No DM because user know he has push commits
 			ToChannels: []string{"channel1"},
 			From:       "manland",


### PR DESCRIPTION
Reformat messages for one or more lines and to avoid wrapping the
commit message in a link which can contain a newline.

Links to the commit are now show as "View Commit" instead of "Commit
Message".

Tests have been updated to reflect that a newline is always added by the Gitlab JSON payload for commit messages.

Resolves #98