### PR TITLE
[GH-74] Configuration change must propagate to client side

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -206,6 +206,8 @@ func (p *Plugin) completeConnectUserToGitlab(w http.ResponseWriter, r *http.Requ
 			"connected":        true,
 			"gitlab_username":  userInfo.GitlabUsername,
 			"gitlab_client_id": config.GitlabOAuthClientID,
+			"gitlab_url":       config.GitlabURL,
+			"organization":     config.GitlabGroup,
 		},
 		&model.WebsocketBroadcast{UserId: userID},
 	)


### PR DESCRIPTION
Summary:
Fix "Configuration change must propagate to client side"

Link:
Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/74