### PR TITLE
[GH-65] Subgroups support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/manland/mattermost-plugin-gitlab
 go 1.13
 
 require (
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/mattermost/mattermost-server v0.0.0-20190927121038-340287890a78
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/xanzy/go-gitlab v0.20.1
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 )

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/server/command.go
+++ b/server/command.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/manland/mattermost-plugin-gitlab/server/gitlab"
 	"github.com/mattermost/mattermost-server/plugin"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -56,18 +58,20 @@ func (p *Plugin) getCommandResponse(args *model.CommandArgs, text string) *model
 	return &model.CommandResponse{}
 }
 
-func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	split := strings.Fields(args.Command)
-	command := split[0]
-	parameters := []string{}
-	action := ""
+func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+
+	var (
+		split      = strings.Fields(args.Command)
+		command    = split[0]
+		action     string
+		parameters []string
+	)
 	if len(split) > 1 {
 		action = split[1]
 	}
 	if len(split) > 2 {
 		parameters = split[2:]
 	}
-
 	if command != "/gitlab" {
 		return &model.CommandResponse{}, nil
 	}
@@ -124,36 +128,52 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			features = strings.Join(parameters[1:], " ")
 		}
 
-		_, owner, repo := parseOwnerAndRepo(parameters[0], config.GitlabURL)
-		if repo == "" {
-			if err := p.SubscribeGroup(info, owner, args.ChannelId, features); err != nil {
-				return p.getCommandResponse(args, err.Error()), nil
+		// Resolve namespace and project name
+		fullPath := normalizePath(parameters[0], config.GitlabURL)
+		namespace, project, err := p.GitlabClient.
+			ResolveNamespaceAndProject(info, fullPath, config.EnablePrivateRepo)
+		if err != nil {
+			if !errors.Is(err, gitlab.ErrNotFound) {
+				p.API.LogError(
+					"unable to resolve subscription namespace and project name",
+					"err", err.Error(),
+				)
 			}
-
-			return p.getCommandResponse(args, fmt.Sprintf("Successfully subscribed to organization %s.", owner)), nil
-		}
-
-		if err := p.Subscribe(info, owner, repo, args.ChannelId, features); err != nil {
-			p.API.LogError("can't subscribe", "err", err.Error())
 			return p.getCommandResponse(args, err.Error()), nil
 		}
 
-		return p.getCommandResponse(args, fmt.Sprintf("Successfully subscribed to %s.", repo)), nil
+		// Create subscription
+		if err := p.Subscribe(info, namespace, project, args.ChannelId, features); err != nil {
+			p.API.LogError(
+				"failed to subscribe",
+				"namespace", namespace,
+				"project", project,
+				"err", err.Error(),
+			)
+			return p.getCommandResponse(args, err.Error()), nil
+		}
+
+		return p.getCommandResponse(
+			args,
+			fmt.Sprintf("Successfully subscribed to %s.", fullPath),
+		), nil
+
 	case "unsubscribe":
+
 		if len(parameters) == 0 {
 			return p.getCommandResponse(args, "Please specify a repository."), nil
 		}
 
-		repo := parameters[0]
-
-		if deleted, err := p.Unsubscribe(args.ChannelId, repo); err != nil {
+		fullPath := normalizePath(parameters[0], config.GitlabURL)
+		if deleted, err := p.Unsubscribe(args.ChannelId, fullPath); err != nil {
 			p.API.LogError("can't unsubscribe channel in command", "err", err.Error())
 			return p.getCommandResponse(args, "Encountered an error trying to unsubscribe. Please try again."), nil
 		} else if !deleted {
 			return p.getCommandResponse(args, "Subscription not found, please check repository name."), nil
 		}
 
-		return p.getCommandResponse(args, fmt.Sprintf("Succesfully unsubscribed from %s.", repo)), nil
+		return p.getCommandResponse(args, fmt.Sprintf("Succesfully unsubscribed from %s.", fullPath)), nil
+
 	case "disconnect":
 		p.disconnectGitlabAccount(args.UserId)
 		return p.getCommandResponse(args, "Disconnected your GitLab account."), nil

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -122,7 +122,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		return err
 	}
 
-	p.GitlabClient = gitlab.New(configuration.GitlabURL, configuration.GitlabGroup, p.checkGroup)
+	p.GitlabClient = gitlab.New(configuration.GitlabURL, configuration.GitlabGroup, p.isNamespaceAllowed)
 
 	return nil
 }

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -115,7 +115,7 @@ func (g *gitlab) GetUnreads(user *GitlabUserInfo) ([]*internGitlab.Todo, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "can't list todo in GitLab api")
 	}
-	notifications := make([]*internGitlab.Todo, len(result))
+	notifications := make([]*internGitlab.Todo, 0, len(result))
 	for _, todo := range result {
 		if g.checkGroup(strings.TrimSuffix(todo.Project.PathWithNamespace, "/"+todo.Project.Path)) != nil {
 			continue

--- a/server/gitlab/gitlab.go
+++ b/server/gitlab/gitlab.go
@@ -2,13 +2,24 @@ package gitlab
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
-	"github.com/pkg/errors"
 	internGitlab "github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
 )
 
-//Gitlab is a client to call GitLab api see New() to build one
+// DefaultRequestTimeout specifies default value for request timeouts.
+const DefaultRequestTimeout = 5 * time.Second
+
+// Errors returned by this package.
+var (
+	ErrNotFound        = errors.New("not found")
+	ErrPrivateResource = errors.New("private resource")
+)
+
+// Gitlab is a client to call GitLab api see New() to build one
 type Gitlab interface {
 	GetCurrentUser(userID string, token oauth2.Token) (*GitlabUserInfo, error)
 	GetUserDetails(user *GitlabUserInfo) (*internGitlab.User, error)
@@ -17,7 +28,16 @@ type Gitlab interface {
 	GetYourPrs(user *GitlabUserInfo) ([]*internGitlab.MergeRequest, error)
 	GetYourAssignments(user *GitlabUserInfo) ([]*internGitlab.Issue, error)
 	GetUnreads(user *GitlabUserInfo) ([]*internGitlab.Todo, error)
-	Exist(user *GitlabUserInfo, owner string, repo string, enablePrivateRepo bool) (bool, error)
+	// ResolveNamespaceAndProject accepts full path to User, Group or namespaced Project and returns corresponding
+	// namespace and project name.
+	//
+	// ErrNotFound will be returned if no resource can be found.
+	// If allowPrivate is set to false, and resolved group/project is private, ErrPrivateResource will be returned.
+	ResolveNamespaceAndProject(
+		userInfo *GitlabUserInfo,
+		fullPath string,
+		allowPrivate bool,
+	) (namespace string, project string, err error)
 }
 
 type gitlab struct {
@@ -26,7 +46,7 @@ type gitlab struct {
 	checkGroup        func(projectNameWithGroup string) error
 }
 
-//New return a client to call GitLab API
+// New return a client to call GitLab API
 func New(enterpriseBaseURL string, gitlabGroup string, checkGroup func(projectNameWithGroup string) error) Gitlab {
 	return &gitlab{enterpriseBaseURL: enterpriseBaseURL, gitlabGroup: gitlabGroup, checkGroup: checkGroup}
 }
@@ -42,7 +62,7 @@ func (g *gitlab) gitlabConnect(token oauth2.Token) (*internGitlab.Client, error)
 
 	client := internGitlab.NewOAuthClient(tc, token.AccessToken)
 	if err := client.SetBaseURL(g.enterpriseBaseURL); err != nil {
-		return nil, errors.Wrap(err, "can't set base url to GitLab client lib")
+		return nil, fmt.Errorf("can't set base url to GitLab client lib: %w", err)
 	}
 	return client, nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -265,7 +265,7 @@ func (p *Plugin) GetToDo(user *gitlab.GitlabUserInfo) (string, error) {
 	notificationCount := 0
 	notificationContent := ""
 	for _, n := range unreads {
-		if p.checkGroup(n.Project.NameWithNamespace) != nil {
+		if p.isNamespaceAllowed(n.Project.NameWithNamespace) != nil {
 			continue
 		}
 		notificationCount++
@@ -318,12 +318,11 @@ func (p *Plugin) GetToDo(user *gitlab.GitlabUserInfo) (string, error) {
 	return text, nil
 }
 
-func (p *Plugin) checkGroup(projectNameWithGroup string) error {
-	config := p.getConfiguration()
+func (p *Plugin) isNamespaceAllowed(namespace string) error {
 
-	group := strings.TrimSpace(config.GitlabGroup)
-	if group != "" && group != strings.Split(projectNameWithGroup, "/")[0] {
-		return fmt.Errorf("Only repositories in the %v group are supported", config.GitlabGroup)
+	allowedNamespace := strings.TrimSpace(p.getConfiguration().GitlabGroup)
+	if allowedNamespace != "" && allowedNamespace != namespace {
+		return fmt.Errorf("only repositories in the %s namespace are allowed", allowedNamespace)
 	}
 
 	return nil

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -3,12 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"strings"
+	"errors"
 
 	"github.com/manland/mattermost-plugin-gitlab/server/gitlab"
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -19,40 +17,23 @@ type Subscriptions struct {
 	Repositories map[string][]*subscription.Subscription
 }
 
-func (p *Plugin) Subscribe(info *gitlab.GitlabUserInfo, owner, repo, channelID, features string) error {
-	if owner == "" {
-		return fmt.Errorf("Invalid repository")
-	}
+func (p *Plugin) Subscribe(info *gitlab.GitlabUserInfo, namespace, project, channelID, features string) error {
 
-	if err := p.checkGroup(owner); err != nil {
+	if err := p.isNamespaceAllowed(namespace); err != nil {
 		return err
 	}
 
-	exist, err := p.GitlabClient.Exist(info, owner, repo, p.getConfiguration().EnablePrivateRepo)
-	if !exist || err != nil {
-		if err != nil {
-			p.API.LogError(fmt.Sprintf("Unable to retrieve repository %s", fullNameFromOwnerAndRepo(owner, repo)), "err", err.Error())
-		}
-		return fmt.Errorf("Unable to retrieve repository %s", fullNameFromOwnerAndRepo(owner, repo))
-	}
-
-	sub, err := subscription.New(channelID, info.UserID, features, fullNameFromOwnerAndRepo(owner, repo))
+	fullPath := fullPathFromNamespaceAndProject(namespace, project)
+	sub, err := subscription.New(channelID, info.UserID, features, fullPath)
 	if err != nil {
 		return err
 	}
 
-	if err := p.AddSubscription(fullNameFromOwnerAndRepo(owner, repo), sub); err != nil {
+	if err := p.AddSubscription(fullPath, sub); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (p *Plugin) SubscribeGroup(info *gitlab.GitlabUserInfo, org, channelID, features string) error {
-	if org == "" {
-		return fmt.Errorf("Invalid group")
-	}
-	return p.Subscribe(info, org, "", channelID, features)
 }
 
 func (p *Plugin) GetSubscriptionsByChannel(channelID string) ([]*subscription.Subscription, error) {
@@ -73,13 +54,14 @@ func (p *Plugin) GetSubscriptionsByChannel(channelID string) ([]*subscription.Su
 	return filteredSubs, nil
 }
 
-func (p *Plugin) AddSubscription(repo string, sub *subscription.Subscription) error {
+func (p *Plugin) AddSubscription(fullPath string, sub *subscription.Subscription) error {
+
 	subs, err := p.GetSubscriptions()
 	if err != nil {
 		return err
 	}
 
-	repoSubs := subs.Repositories[repo]
+	repoSubs := subs.Repositories[fullPath]
 	if repoSubs == nil {
 		repoSubs = []*subscription.Subscription{sub}
 	} else {
@@ -97,7 +79,7 @@ func (p *Plugin) AddSubscription(repo string, sub *subscription.Subscription) er
 		}
 	}
 
-	subs.Repositories[repo] = repoSubs
+	subs.Repositories[fullPath] = repoSubs
 	return p.StoreSubscriptions(subs)
 }
 
@@ -132,9 +114,13 @@ func (p *Plugin) StoreSubscriptions(s *Subscriptions) error {
 	return nil
 }
 
-func (p *Plugin) GetSubscribedChannelsForRepository(fullNameOwnerAndRepo string, repoPublic bool) []*subscription.Subscription {
-	group := strings.Split(fullNameOwnerAndRepo, "/")[0]
-	subsForRepo := []*subscription.Subscription{}
+func (p *Plugin) GetSubscribedChannelsForProject(
+	namespace string,
+	project string,
+	isPublicVisibility bool,
+) []*subscription.Subscription {
+
+	var subsForRepo []*subscription.Subscription
 
 	subs, err := p.GetSubscriptions()
 	if err != nil {
@@ -143,24 +129,24 @@ func (p *Plugin) GetSubscribedChannelsForRepository(fullNameOwnerAndRepo string,
 	}
 
 	// Add subscriptions for the specific repo
-	if subs.Repositories[fullNameOwnerAndRepo] != nil {
-		subsForRepo = append(subsForRepo, subs.Repositories[fullNameOwnerAndRepo]...)
+	fullPath := fullPathFromNamespaceAndProject(namespace, project)
+	if subs.Repositories[fullPath] != nil {
+		subsForRepo = append(subsForRepo, subs.Repositories[fullPath]...)
 	}
 
-	// Add subscriptions for the organization
-	groupKey := fullNameFromOwnerAndRepo(group, "")
-	if subs.Repositories[groupKey] != nil {
-		subsForRepo = append(subsForRepo, subs.Repositories[groupKey]...)
+	// Add subscriptions for the namespace
+	namespacePath := fullPathFromNamespaceAndProject(namespace, "")
+	if namespacePath != fullPath && subs.Repositories[namespacePath] != nil {
+		subsForRepo = append(subsForRepo, subs.Repositories[namespacePath]...)
 	}
 
 	if len(subsForRepo) == 0 {
 		return nil
 	}
 
-	subsToReturn := []*subscription.Subscription{}
-
+	subsToReturn := make([]*subscription.Subscription, len(subsForRepo))
 	for _, sub := range subsForRepo {
-		if !repoPublic && !p.permissionToRepo(sub.CreatorID, fullNameOwnerAndRepo) {
+		if !isPublicVisibility && !p.permissionToProject(sub.CreatorID, namespace, project) {
 			continue
 		}
 		subsToReturn = append(subsToReturn, sub)
@@ -169,48 +155,50 @@ func (p *Plugin) GetSubscribedChannelsForRepository(fullNameOwnerAndRepo string,
 	return subsToReturn
 }
 
-// Unsubscribe deletes the link between channelID and repo
-// returns true if repo was found, else false
-func (p *Plugin) Unsubscribe(channelID string, repo string) (bool, error) {
-	config := p.getConfiguration()
+// Unsubscribe deletes the link between namespace/project and channelID.
+// Returns true if subscription was found, false otherwise.
+func (p *Plugin) Unsubscribe(channelID string, fullPath string) (bool, error) {
 
-	if repo == "" {
-		return false, errors.New("Invalid repository")
+	if fullPath == "" {
+		return false, errors.New("invalid repository")
 	}
-
-	_, owner, project := parseOwnerAndRepo(repo, config.GitlabURL)
-	repo = fullNameFromOwnerAndRepo(owner, project)
 
 	subs, err := p.GetSubscriptions()
 	if err != nil {
 		return false, err
 	}
 
-	repoSubs := subs.Repositories[repo]
-	if repoSubs == nil {
+	var removed bool
+
+	// We don't know whether fullPath is a namespace or project, so we have to check both cases
+	for _, path := range []string{fullPath, fullPath + "/"} {
+
+		pathSubs := subs.Repositories[path]
+		if pathSubs == nil {
+			continue
+		}
+
+		pathRemoved := false
+		for index, sub := range pathSubs {
+			if sub.ChannelID == channelID {
+				pathSubs = append(pathSubs[:index], pathSubs[index+1:]...)
+				pathRemoved = true
+				break
+			}
+		}
+
+		if pathRemoved {
+			if len(pathSubs) > 0 {
+				subs.Repositories[path] = pathSubs
+			} else {
+				delete(subs.Repositories, path)
+			}
+			removed = true
+		}
+	}
+
+	if !removed {
 		return false, nil
 	}
-
-	removed := false
-	for index, sub := range repoSubs {
-		if sub.ChannelID == channelID {
-			repoSubs = append(repoSubs[:index], repoSubs[index+1:]...)
-			removed = true
-			break
-		}
-	}
-
-	if removed {
-		if len(repoSubs) > 0 {
-			subs.Repositories[repo] = repoSubs
-		} else {
-			delete(subs.Repositories, repo)
-		}
-		if err := p.StoreSubscriptions(subs); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-
-	return false, nil
+	return true, p.StoreSubscriptions(subs)
 }

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -125,7 +125,7 @@ func (p *Plugin) GetSubscribedChannelsForProject(
 	subs, err := p.GetSubscriptions()
 	if err != nil {
 		p.API.LogError("can't retrieve subscriptions", "err", err.Error())
-		return subsForRepo
+		return nil
 	}
 
 	// Add subscriptions for the specific repo

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -144,7 +144,7 @@ func (p *Plugin) GetSubscribedChannelsForProject(
 		return nil
 	}
 
-	subsToReturn := make([]*subscription.Subscription, len(subsForRepo))
+	subsToReturn := make([]*subscription.Subscription, 0, len(subsForRepo))
 	for _, sub := range subsForRepo {
 		if !isPublicVisibility && !p.permissionToProject(sub.CreatorID, namespace, project) {
 			continue

--- a/server/utils.go
+++ b/server/utils.go
@@ -78,25 +78,16 @@ func decrypt(key []byte, text string) (string, error) {
 	return string(unpadMsg), nil
 }
 
-func parseOwnerAndRepo(full, baseURL string) (string, string, string) {
+// normalizePath is responsible for parsing GitLab project URL leaving only <GROUP>/<SUBGROUP>/<REPO> components.
+func normalizePath(full, baseURL string) string {
+
 	if baseURL == "" {
 		baseURL = "https://gitlab.com/"
 	} else if !strings.HasSuffix(baseURL, "/") {
 		baseURL = baseURL + "/"
 	}
-	full = strings.TrimSuffix(strings.TrimSpace(strings.Replace(full, baseURL, "", 1)), "/")
-	splitStr := strings.Split(full, "/")
 
-	if len(splitStr) == 1 {
-		owner := splitStr[0]
-		return owner, owner, ""
-	} else if len(splitStr) != 2 {
-		return "", "", ""
-	}
-	owner := splitStr[0]
-	repo := splitStr[1]
-
-	return fmt.Sprintf("%s/%s", owner, repo), owner, repo
+	return strings.TrimSuffix(strings.TrimSpace(strings.Replace(full, baseURL, "", 1)), "/")
 }
 
 func parseGitlabUsernamesFromText(text string) []string {
@@ -128,6 +119,6 @@ func parseGitlabUsernamesFromText(text string) []string {
 	return usernames
 }
 
-func fullNameFromOwnerAndRepo(owner, repo string) string {
-	return fmt.Sprintf("%s/%s", owner, repo)
+func fullPathFromNamespaceAndProject(namespace, project string) string {
+	return fmt.Sprintf("%s/%s", namespace, project)
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -34,31 +34,27 @@ func TestParseGitlabUsernamesFromText(t *testing.T) {
 	}
 }
 
-func TestParseOwnerAndRepo(t *testing.T) {
+func TestNormalizePath(t *testing.T) {
 	tcs := []struct {
-		Full          string
-		BaseURL       string
-		ExpectedOwner string
-		ExpectedRepo  string
+		Full     string
+		BaseURL  string
+		Expected string
 	}{
-		{Full: "mattermost", BaseURL: "", ExpectedOwner: "mattermost", ExpectedRepo: ""},
-		{Full: "mattermost", BaseURL: "https://gitlab.com/", ExpectedOwner: "mattermost", ExpectedRepo: ""},
-		{Full: "https://gitlab.com/mattermost", BaseURL: "", ExpectedOwner: "mattermost", ExpectedRepo: ""},
-		{Full: "https://gitlab.com/mattermost", BaseURL: "https://gitlab.com/", ExpectedOwner: "mattermost", ExpectedRepo: ""},
-		{Full: "mattermost/mattermost-server", BaseURL: "", ExpectedOwner: "mattermost", ExpectedRepo: "mattermost-server"},
-		{Full: "mattermost/mattermost-server", BaseURL: "https://gitlab.com/", ExpectedOwner: "mattermost", ExpectedRepo: "mattermost-server"},
-		{Full: "https://gitlab.com/mattermost/mattermost-server", BaseURL: "", ExpectedOwner: "mattermost", ExpectedRepo: "mattermost-server"},
-		{Full: "https://gitlab.com/mattermost/mattermost-server", BaseURL: "https://gitlab.com/", ExpectedOwner: "mattermost", ExpectedRepo: "mattermost-server"},
-		{Full: "", BaseURL: "", ExpectedOwner: "", ExpectedRepo: ""},
-		{Full: "mattermost/mattermost/invalid_repo_url", BaseURL: "", ExpectedOwner: "", ExpectedRepo: ""},
-		{Full: "https://gitlab.com/mattermost/mattermost/invalid_repo_url", BaseURL: "", ExpectedOwner: "", ExpectedRepo: ""},
-		{Full: "http://127.0.0.1:3000/manland/personal", BaseURL: "http://127.0.0.1:3000", ExpectedOwner: "manland", ExpectedRepo: "personal"},
+		{Full: "mattermost", BaseURL: "", Expected: "mattermost"},
+		{Full: "mattermost", BaseURL: "https://gitlab.com/", Expected: "mattermost"},
+		{Full: "https://gitlab.com/mattermost", BaseURL: "", Expected: "mattermost"},
+		{Full: "https://gitlab.com/mattermost", BaseURL: "https://gitlab.com/", Expected: "mattermost"},
+		{Full: "mattermost/mattermost-server", BaseURL: "", Expected: "mattermost/mattermost-server"},
+		{Full: "mattermost/mattermost-server", BaseURL: "https://gitlab.com/", Expected: "mattermost/mattermost-server"},
+		{Full: "https://gitlab.com/mattermost/mattermost-server", BaseURL: "", Expected: "mattermost/mattermost-server"},
+		{Full: "https://gitlab.com/mattermost/mattermost-server", BaseURL: "https://gitlab.com/", Expected: "mattermost/mattermost-server"},
+		{Full: "", BaseURL: "", Expected: ""},
+		{Full: "group/subgroup/project", BaseURL: "", Expected: "group/subgroup/project"},
+		{Full: "https://gitlab.com/group/subgroup/project", BaseURL: "", Expected: "group/subgroup/project"},
+		{Full: "http://127.0.0.1:3000/manland/personal", BaseURL: "http://127.0.0.1:3000", Expected: "manland/personal"},
 	}
 
 	for _, tc := range tcs {
-		_, owner, repo := parseOwnerAndRepo(tc.Full, tc.BaseURL)
-
-		assert.Equal(t, owner, tc.ExpectedOwner)
-		assert.Equal(t, repo, tc.ExpectedRepo)
+		assert.Equal(t, tc.Expected, normalizePath(tc.Full, tc.BaseURL))
 	}
 }

--- a/server/webhook/issue.go
+++ b/server/webhook/issue.go
@@ -77,7 +77,11 @@ func (w *webhook) handleChannelIssue(event *gitlab.IssueEvent) ([]*HandleWebhook
 
 	if len(message) > 0 {
 		toChannels := make([]string, 0)
-		subs := w.gitlabRetreiver.GetSubscribedChannelsForRepository(repo.PathWithNamespace, repo.Visibility == gitlab.PublicVisibility)
+		subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+			repo.Namespace,
+			projectPath(repo.Namespace, repo.PathWithNamespace),
+			repo.Visibility == gitlab.PublicVisibility,
+		)
 		for _, sub := range subs {
 			if !sub.Issues() {
 				continue

--- a/server/webhook/issue.go
+++ b/server/webhook/issue.go
@@ -77,9 +77,9 @@ func (w *webhook) handleChannelIssue(event *gitlab.IssueEvent) ([]*HandleWebhook
 
 	if len(message) > 0 {
 		toChannels := make([]string, 0)
+		namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
 		subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-			repo.Namespace,
-			projectPath(repo.Namespace, repo.PathWithNamespace),
+			namespace, project,
 			repo.Visibility == gitlab.PublicVisibility,
 		)
 		for _, sub := range subs {

--- a/server/webhook/issue_test.go
+++ b/server/webhook/issue_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
@@ -30,6 +31,23 @@ var testDataIssue = []testDataIssueStr{
 			From:       "root",
 		}, {
 			Message:    "#### test new issue\n##### [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)\n# new issue by [root](http://my.gitlab.com/root) on [2019-04-06 21:03:04 UTC](http://localhost:3000/manland/webhook/issues/1)\n\nhello world!",
+			ToUsers:    []string{},
+			ToChannels: []string{"channel1"},
+			From:       "root",
+		}},
+	}, {
+		testTitle: "root open issue with manland assignee and display in channel1 (subgroup)",
+		fixture:   strings.Replace(NewIssue, "manland/webhook", "manland/subgroup/webhook", -1),
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "issues", Repository: "manland/subgroup/webhook"},
+		}),
+		res: []*HandleWebhook{{
+			Message:    "[root](http://my.gitlab.com/root) assigned you to issue [manland/subgroup/webhook#1](http://localhost:3000/manland/subgroup/webhook/issues/1)",
+			ToUsers:    []string{"manland"},
+			ToChannels: []string{},
+			From:       "root",
+		}, {
+			Message:    "#### test new issue\n##### [manland/subgroup/webhook#1](http://localhost:3000/manland/subgroup/webhook/issues/1)\n# new issue by [root](http://my.gitlab.com/root) on [2019-04-06 21:03:04 UTC](http://localhost:3000/manland/subgroup/webhook/issues/1)\n\nhello world!",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "root",

--- a/server/webhook/merge_request.go
+++ b/server/webhook/merge_request.go
@@ -77,7 +77,11 @@ func (w *webhook) handleChannelMergeRequest(event *gitlab.MergeEvent) ([]*Handle
 
 	if len(message) > 0 {
 		toChannels := make([]string, 0)
-		subs := w.gitlabRetreiver.GetSubscribedChannelsForRepository(repo.PathWithNamespace, repo.Visibility == gitlab.PublicVisibility)
+		subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+			repo.Namespace,
+			projectPath(repo.Namespace, repo.PathWithNamespace),
+			repo.Visibility == gitlab.PublicVisibility,
+		)
 		for _, sub := range subs {
 			if !sub.Merges() {
 				continue

--- a/server/webhook/merge_request.go
+++ b/server/webhook/merge_request.go
@@ -77,9 +77,9 @@ func (w *webhook) handleChannelMergeRequest(event *gitlab.MergeEvent) ([]*Handle
 
 	if len(message) > 0 {
 		toChannels := make([]string, 0)
+		namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
 		subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-			repo.Namespace,
-			projectPath(repo.Namespace, repo.PathWithNamespace),
+			namespace, project,
 			repo.Visibility == gitlab.PublicVisibility,
 		)
 		for _, sub := range subs {

--- a/server/webhook/merge_request_test.go
+++ b/server/webhook/merge_request_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
@@ -30,6 +31,23 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			From:       "root",
 		}, {
 			Message:    "#### Master\n##### [manland/webhook#4](http://localhost:3000/manland/webhook/merge_requests/4) new merge-request by [root](http://my.gitlab.com/root) on [2019-04-03 21:07:32 UTC](http://localhost:3000/manland/webhook/merge_requests/4)\n\ntest open merge request",
+			ToUsers:    []string{},
+			ToChannels: []string{"channel1"},
+			From:       "root",
+		}},
+	}, {
+		testTitle: "root open merge request for manland and display in channel1 (subgroup)",
+		fixture:   strings.Replace(OpenMergeRequest, "manland/webhook", "manland/subgroup/webhook", -1),
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/subgroup/webhook"},
+		}),
+		res: []*HandleWebhook{{
+			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/subgroup/webhook#4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4)",
+			ToUsers:    []string{"manland"},
+			ToChannels: []string{},
+			From:       "root",
+		}, {
+			Message:    "#### Master\n##### [manland/subgroup/webhook#4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4) new merge-request by [root](http://my.gitlab.com/root) on [2019-04-03 21:07:32 UTC](http://localhost:3000/manland/subgroup/webhook/merge_requests/4)\n\ntest open merge request",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "root",

--- a/server/webhook/note.go
+++ b/server/webhook/note.go
@@ -58,7 +58,11 @@ func (w *webhook) handleChannelIssueComment(event *gitlab.IssueCommentEvent) ([]
 	message := fmt.Sprintf("[%s](%s) New comment by [%s](%s) on [#%v %s](%s):\n\n%s", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Issue.IID, event.Issue.Title, event.ObjectAttributes.URL, body)
 
 	toChannels := make([]string, 0)
-	subs := w.gitlabRetreiver.GetSubscribedChannelsForRepository(repo.PathWithNamespace, repo.Visibility == gitlab.PublicVisibility)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		repo.Namespace,
+		projectPath(repo.Namespace, repo.PathWithNamespace),
+		repo.Visibility == gitlab.PublicVisibility,
+	)
 	for _, sub := range subs {
 		if !sub.IssueComments() {
 			continue
@@ -120,7 +124,11 @@ func (w *webhook) handleChannelMergeRequestComment(event *gitlab.MergeCommentEve
 	message := fmt.Sprintf("[%s](%s) New comment by [%s](%s) on [#%v %s](%s):\n\n%s", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.MergeRequest.IID, event.MergeRequest.Title, event.ObjectAttributes.URL, body)
 
 	toChannels := make([]string, 0)
-	subs := w.gitlabRetreiver.GetSubscribedChannelsForRepository(repo.PathWithNamespace, repo.Visibility == gitlab.PublicVisibility)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		repo.Namespace,
+		projectPath(repo.Namespace, repo.PathWithNamespace),
+		repo.Visibility == gitlab.PublicVisibility,
+	)
 	for _, sub := range subs {
 		if !sub.MergeRequestComments() {
 			continue

--- a/server/webhook/note.go
+++ b/server/webhook/note.go
@@ -58,9 +58,9 @@ func (w *webhook) handleChannelIssueComment(event *gitlab.IssueCommentEvent) ([]
 	message := fmt.Sprintf("[%s](%s) New comment by [%s](%s) on [#%v %s](%s):\n\n%s", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Issue.IID, event.Issue.Title, event.ObjectAttributes.URL, body)
 
 	toChannels := make([]string, 0)
+	namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-		repo.Namespace,
-		projectPath(repo.Namespace, repo.PathWithNamespace),
+		namespace, project,
 		repo.Visibility == gitlab.PublicVisibility,
 	)
 	for _, sub := range subs {
@@ -124,9 +124,9 @@ func (w *webhook) handleChannelMergeRequestComment(event *gitlab.MergeCommentEve
 	message := fmt.Sprintf("[%s](%s) New comment by [%s](%s) on [#%v %s](%s):\n\n%s", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.MergeRequest.IID, event.MergeRequest.Title, event.ObjectAttributes.URL, body)
 
 	toChannels := make([]string, 0)
+	namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-		repo.Namespace,
-		projectPath(repo.Namespace, repo.PathWithNamespace),
+		namespace, project,
 		repo.Visibility == gitlab.PublicVisibility,
 	)
 	for _, sub := range subs {

--- a/server/webhook/note_test.go
+++ b/server/webhook/note_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
@@ -33,6 +34,24 @@ var testDataNote = []testDataNoteStr{
 			From:       "manland",
 		}, {
 			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) New comment by [manland](http://my.gitlab.com/manland) on [#1 test new issue](http://localhost:3000/manland/webhook/issues/1#note_997):\n\ncoucou3",
+			ToUsers:    []string{},
+			ToChannels: []string{"channel1"},
+			From:       "manland",
+		}},
+	}, {
+		testTitle: "manland comment issue of root (subgroup)",
+		kind:      "issue",
+		fixture:   strings.Replace(IssueComment, "manland/webhook", "manland/subgroup/webhook", -1),
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "issue_comments", Repository: "manland/subgroup/webhook"},
+		}),
+		res: []*HandleWebhook{{
+			Message:    "[manland](http://my.gitlab.com/manland) commented on your issue [manland/subgroup/webhook#1](http://localhost:3000/manland/subgroup/webhook/issues/1#note_997)",
+			ToUsers:    []string{"root"},
+			ToChannels: []string{},
+			From:       "manland",
+		}, {
+			Message:    "[manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook) New comment by [manland](http://my.gitlab.com/manland) on [#1 test new issue](http://localhost:3000/manland/subgroup/webhook/issues/1#note_997):\n\ncoucou3",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "manland",

--- a/server/webhook/pipeline.go
+++ b/server/webhook/pipeline.go
@@ -65,9 +65,9 @@ func (w *webhook) handleChannelPipeline(event *gitlab.PipelineEvent) ([]*HandleW
 	}
 
 	toChannels := make([]string, 0)
+	namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-		repo.Namespace,
-		projectPath(repo.Namespace, repo.PathWithNamespace),
+		namespace, project,
 		repo.Visibility == gitlab.PublicVisibility,
 	)
 	for _, sub := range subs {

--- a/server/webhook/pipeline.go
+++ b/server/webhook/pipeline.go
@@ -65,7 +65,11 @@ func (w *webhook) handleChannelPipeline(event *gitlab.PipelineEvent) ([]*HandleW
 	}
 
 	toChannels := make([]string, 0)
-	subs := w.gitlabRetreiver.GetSubscribedChannelsForRepository(repo.PathWithNamespace, repo.Visibility == gitlab.PublicVisibility)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		repo.Namespace,
+		projectPath(repo.Namespace, repo.PathWithNamespace),
+		repo.Visibility == gitlab.PublicVisibility,
+	)
 	for _, sub := range subs {
 		if !sub.Pipeline() {
 			continue

--- a/server/webhook/pipeline_test.go
+++ b/server/webhook/pipeline_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
@@ -32,6 +33,18 @@ var testDataPipeline = []testDataPipelineStr{
 		}),
 		res: []*HandleWebhook{{
 			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) New pipeline by [root](http://my.gitlab.com/root) for [Start gitlab-ci](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
+			ToUsers:    []string{}, // No DM because user know he has launch a pipeline
+			ToChannels: []string{"channel1"},
+			From:       "root",
+		}},
+	}, {
+		testTitle: "root start a pipeline in running (subgroup)",
+		fixture:   strings.Replace(PipelineRun, "manland/webhook", "manland/subgroup/webhook", -1),
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "pipeline", Repository: "manland/subgroup/webhook"},
+		}),
+		res: []*HandleWebhook{{
+			Message:    "[manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook) New pipeline by [root](http://my.gitlab.com/root) for [Start gitlab-ci](http://localhost:3000/manland/subgroup/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
 			ToUsers:    []string{}, // No DM because user know he has launch a pipeline
 			ToChannels: []string{"channel1"},
 			From:       "root",

--- a/server/webhook/push.go
+++ b/server/webhook/push.go
@@ -57,9 +57,9 @@ func (w *webhook) handleChannelPush(event *gitlab.PushEvent) ([]*HandleWebhook, 
 	}
 
 	toChannels := make([]string, 0)
+	namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-		repo.Namespace,
-		projectPath(repo.Namespace, repo.PathWithNamespace),
+		namespace, project,
 		repo.Visibility == gitlab.PublicVisibility,
 	)
 	for _, sub := range subs {

--- a/server/webhook/push.go
+++ b/server/webhook/push.go
@@ -57,7 +57,11 @@ func (w *webhook) handleChannelPush(event *gitlab.PushEvent) ([]*HandleWebhook, 
 	}
 
 	toChannels := make([]string, 0)
-	subs := w.gitlabRetreiver.GetSubscribedChannelsForRepository(repo.PathWithNamespace, repo.Visibility == gitlab.PublicVisibility)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		repo.Namespace,
+		projectPath(repo.Namespace, repo.PathWithNamespace),
+		repo.Visibility == gitlab.PublicVisibility,
+	)
 	for _, sub := range subs {
 		if !sub.Pushes() {
 			continue

--- a/server/webhook/push_test.go
+++ b/server/webhook/push_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
@@ -16,7 +17,8 @@ type testDataPushStr struct {
 	res             []*HandleWebhook
 }
 
-var testDataPush = []testDataPushStr{{
+var testDataPush = []testDataPushStr{
+	{
 		testTitle: "manland push 1 commit",
 		fixture:   PushEvent,
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
@@ -30,6 +32,19 @@ var testDataPush = []testDataPushStr{{
 			From:       "manland",
 		}},
 	}, {
+		testTitle: "manland push 1 commit (subgroup)",
+		fixture:   strings.Replace(PushEvent, "manland/webhook", "manland/subgroup/webhook", -1),
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "pushes", Repository: "manland/subgroup/webhook"},
+		}),
+		res: []*HandleWebhook{{
+			Message: "[manland](http://my.gitlab.com/manland) has pushed 1 commit to [manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook)\n" +
+				"really cool commit\n[View Commit](http://localhost:3000/manland/subgroup/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)",
+			ToUsers:    []string{}, // No DM because user know he has push commits
+			ToChannels: []string{"channel1"},
+			From:       "manland",
+		}},
+	}, {
 		testTitle: "manland push 2 commits",
 		fixture:   pushEventWithTwoCommits,
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
@@ -37,13 +52,13 @@ var testDataPush = []testDataPushStr{{
 		}),
 		res: []*HandleWebhook{{
 			Message: "[manland](http://my.gitlab.com/manland) has pushed 2 commits to [manland/webhook](http://localhost:3000/manland/webhook)\n" +
-				"really cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)\n"+
+				"really cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)\n" +
 				"another cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/595f2a068cce60954565b224bc7c966c9e708cbf)",
 			ToUsers:    []string{}, // No DM because user know he has push commits
 			ToChannels: []string{"channel1"},
 			From:       "manland",
 		}},
-	},	{
+	}, {
 		testTitle: "manland push 0 commits",
 		fixture:   pushEventWithoutCommits,
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{

--- a/server/webhook/tag.go
+++ b/server/webhook/tag.go
@@ -48,7 +48,11 @@ func (w *webhook) handleChannelTag(event *gitlab.TagEvent) ([]*HandleWebhook, er
 	message := fmt.Sprintf("[%s](%s) New tag [%s](%s) by [%s](%s): %s", repo.PathWithNamespace, repo.WebURL, tagName, event.Commits[0].URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Message)
 
 	toChannels := make([]string, 0)
-	subs := w.gitlabRetreiver.GetSubscribedChannelsForRepository(repo.PathWithNamespace, repo.Visibility == gitlab.PublicVisibility)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		repo.Namespace,
+		projectPath(repo.Namespace, repo.PathWithNamespace),
+		repo.Visibility == gitlab.PublicVisibility,
+	)
 	for _, sub := range subs {
 		if !sub.Tag() {
 			continue

--- a/server/webhook/tag.go
+++ b/server/webhook/tag.go
@@ -48,9 +48,9 @@ func (w *webhook) handleChannelTag(event *gitlab.TagEvent) ([]*HandleWebhook, er
 	message := fmt.Sprintf("[%s](%s) New tag [%s](%s) by [%s](%s): %s", repo.PathWithNamespace, repo.WebURL, tagName, event.Commits[0].URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Message)
 
 	toChannels := make([]string, 0)
+	namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-		repo.Namespace,
-		projectPath(repo.Namespace, repo.PathWithNamespace),
+		namespace, project,
 		repo.Visibility == gitlab.PublicVisibility,
 	)
 	for _, sub := range subs {

--- a/server/webhook/tag_test.go
+++ b/server/webhook/tag_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
@@ -25,6 +26,19 @@ var testDataTag = []testDataTagStr{
 		}),
 		res: []*HandleWebhook{{
 			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) New tag [tag1](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663) by [manland](http://my.gitlab.com/manland): Really beatiful tag",
+			ToUsers:    []string{}, // No DM because user know he has created a tag
+			ToChannels: []string{"channel1"},
+			From:       "manland",
+		}},
+	},
+	{
+		testTitle: "manland create a tag (subgroup)",
+		fixture:   strings.Replace(SimpleTag, "manland/webhook", "manland/subgroup/webhook", -1),
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "tag", Repository: "manland/subgroup/webhook"},
+		}),
+		res: []*HandleWebhook{{
+			Message:    "[manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook) New tag [tag1](http://localhost:3000/manland/subgroup/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663) by [manland](http://my.gitlab.com/manland): Really beatiful tag",
 			ToUsers:    []string{}, // No DM because user know he has created a tag
 			ToChannels: []string{"channel1"},
 			From:       "manland",

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -134,6 +134,18 @@ func labelToString(a []gitlab.Label) string {
 	return strings.Join(names, ", ")
 }
 
-func projectPath(namespace, pathWithNamespace string) string {
-	return strings.TrimPrefix(pathWithNamespace, namespace+"/")
+// normalizeNamespacedProject converts data from web hooks to format expected by our plugin.
+//
+// The difference is that this plugin requires separate namespace and project path parts.
+// However in web hooks only pathWithNamespace is available.
+// In other words,
+// group/subgroup/project
+// becomes
+// namespace = group/subgroup; project = project
+func normalizeNamespacedProject(pathWithNamespace string) (namespace string, project string) {
+	splits := strings.Split(pathWithNamespace, "/")
+	if len(splits) < 2 {
+		return "", ""
+	}
+	return strings.Join(splits[:len(splits)-1], "/"), splits[len(splits)-1]
 }

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -17,8 +17,8 @@ type GitlabRetreiver interface {
 	GetUsernameByID(id int) string
 	// ParseGitlabUsernamesFromText from a text return an array of username
 	ParseGitlabUsernamesFromText(text string) []string
-	// GetSubscribedChannelsForRepository return all subscription for this repository
-	GetSubscribedChannelsForRepository(repoWithNamespace string, isPublicVisibility bool) []*subscription.Subscription
+	// GetSubscribedChannelsForProject returns all subscriptions for given project.
+	GetSubscribedChannelsForProject(namespace, project string, isPublicVisibility bool) []*subscription.Subscription
 }
 
 type HandleWebhook struct {
@@ -132,4 +132,8 @@ func labelToString(a []gitlab.Label) string {
 		names[index] = l.Name
 	}
 	return strings.Join(names, ", ")
+}
+
+func projectPath(namespace, pathWithNamespace string) string {
+	return strings.TrimPrefix(pathWithNamespace, namespace+"/")
 }

--- a/server/webhook/webhook_test.go
+++ b/server/webhook/webhook_test.go
@@ -2,7 +2,9 @@ package webhook
 
 import (
 	"fmt"
+	"testing"
 
+	"github.com/bmizerany/assert"
 	"github.com/manland/mattermost-plugin-gitlab/server/subscription"
 )
 
@@ -36,4 +38,38 @@ func (*fakeWebhook) ParseGitlabUsernamesFromText(body string) []string {
 
 func (f *fakeWebhook) GetSubscribedChannelsForProject(namespace, project string, isPublicVisibility bool) []*subscription.Subscription {
 	return f.subs
+}
+
+type testDataNormalizeNamespacedProjectStr struct {
+	Title                  string
+	InputNamespace         string
+	InputPathWithNamespace string
+	ExpectedNamespace      string
+	ExpectedProject        string
+}
+
+var testDataNormalizeNamespacedProject = []testDataNormalizeNamespacedProjectStr{
+	{
+		Title:                  "project in group",
+		InputPathWithNamespace: "group/project",
+		ExpectedNamespace:      "group",
+		ExpectedProject:        "project",
+	},
+	{
+		Title:                  "project in subgroup",
+		InputPathWithNamespace: "group/subgroup/project",
+		ExpectedNamespace:      "group/subgroup",
+		ExpectedProject:        "project",
+	},
+}
+
+func TestNormalizeNamespacedProject(t *testing.T) {
+	t.Parallel()
+	for _, test := range testDataNormalizeNamespacedProject {
+		t.Run(test.Title, func(t *testing.T) {
+			namespace, project := normalizeNamespacedProject(test.InputPathWithNamespace)
+			assert.Equal(t, test.ExpectedNamespace, namespace)
+			assert.Equal(t, test.ExpectedProject, project)
+		})
+	}
 }

--- a/server/webhook/webhook_test.go
+++ b/server/webhook/webhook_test.go
@@ -34,6 +34,6 @@ func (*fakeWebhook) ParseGitlabUsernamesFromText(body string) []string {
 	return []string{}
 }
 
-func (f *fakeWebhook) GetSubscribedChannelsForRepository(repoWithNamespace string, isPublicVisibility bool) []*subscription.Subscription {
+func (f *fakeWebhook) GetSubscribedChannelsForProject(namespace, project string, isPublicVisibility bool) []*subscription.Subscription {
 	return f.subs
 }


### PR DESCRIPTION
#### Summary

This commit adds support for GitLab subgroups in `subscribe`/`unsubscribe` commands and webhook handlers.

#### Ticket Link

Closes https://github.com/mattermost/mattermost-plugin-gitlab/issues/65

#### Description

The most important change that adds subgroups support is located here:
https://github.com/mattermost/mattermost-plugin-gitlab/pull/125/files#diff-9c0c4b23069bf3f449da9fa0ee9d8a21R129-R209
When a new subscription is created, the plugin will not try to parse the path into group/project anymore and will always contact GitLab for information about the path.

Changes in other files are mostly related to new tests and functions signatures changes, making them accept `namespace` and `project` pairs instead of `fullPath`. This way plugin doesn't need to make extra API calls after new webhooks received.