### PR TITLE
Fix broken Markdown link caused by line wrapping for pipeline webhook

### DIFF
--- a/server/webhook/pipeline.go
+++ b/server/webhook/pipeline.go
@@ -25,7 +25,7 @@ func (w *webhook) handleDMPipeline(event *gitlab.PipelineEvent) ([]*HandleWebhoo
 	handlers := []*HandleWebhook{}
 
 	if event.ObjectAttributes.Status == "failed" {
-		message := fmt.Sprintf("[%s](%s) Your pipeline has failed for %s[%s](%s)", repo.PathWithNamespace, repo.WebURL, event.Commit.Message, "View Commit", event.Commit.URL)
+		message := fmt.Sprintf("[%s](%s) Your pipeline has failed for %s[View Commit](%s)", repo.PathWithNamespace, repo.WebURL, event.Commit.Message, event.Commit.URL)
 		handlers = append(handlers, &HandleWebhook{
 			Message:    message,
 			From:       "", // don't put senderGitlabUsername because we filter message where from == to

--- a/server/webhook/pipeline.go
+++ b/server/webhook/pipeline.go
@@ -25,7 +25,7 @@ func (w *webhook) handleDMPipeline(event *gitlab.PipelineEvent) ([]*HandleWebhoo
 	handlers := []*HandleWebhook{}
 
 	if event.ObjectAttributes.Status == "failed" {
-		message := fmt.Sprintf("[%s](%s) Your pipeline has failed for [%s](%s)", repo.PathWithNamespace, repo.WebURL, event.Commit.Message, event.Commit.URL)
+		message := fmt.Sprintf("[%s](%s) Your pipeline has failed for %s[%s](%s)", repo.PathWithNamespace, repo.WebURL, event.Commit.Message, "View Commit", event.Commit.URL)
 		handlers = append(handlers, &HandleWebhook{
 			Message:    message,
 			From:       "", // don't put senderGitlabUsername because we filter message where from == to
@@ -55,11 +55,11 @@ func (w *webhook) handleChannelPipeline(event *gitlab.PipelineEvent) ([]*HandleW
 
 	switch event.ObjectAttributes.Status {
 	case "running":
-		message = fmt.Sprintf("[%s](%s) New pipeline by [%s](%s) for [%s](%s)", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Commit.Message, event.Commit.URL)
+		message = fmt.Sprintf("[%s](%s) New pipeline by [%s](%s) for %s[%s](%s)", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Commit.Message, "View Commit", event.Commit.URL)
 	case "success":
-		message = fmt.Sprintf("[%s](%s) Pipeline by [%s](%s) success for [%s](%s)", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Commit.Message, event.Commit.URL)
+		message = fmt.Sprintf("[%s](%s) Pipeline by [%s](%s) success for %s[%s](%s)", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Commit.Message, "View Commit", event.Commit.URL)
 	case "failed":
-		message = fmt.Sprintf("[%s](%s) Pipeline by [%s](%s) fail for [%s](%s)", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Commit.Message, event.Commit.URL)
+		message = fmt.Sprintf("[%s](%s) Pipeline by [%s](%s) fail for %s[%s](%s)", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Commit.Message, "View Commit", event.Commit.URL)
 	default:
 		return res, nil
 	}

--- a/server/webhook/pipeline_fixture_test.go
+++ b/server/webhook/pipeline_fixture_test.go
@@ -37,7 +37,7 @@ const PipelinePending = `{
 	},
 	"commit":{
 		"id":"ec0a1bcd4580bfec3495674e412f4834ee2c2550",
-		"message":"Start gitlab-ci",
+		"message":"Start gitlab-ci\n",
 		"timestamp":"2019-04-17T20:38:43Z",
 		"url":"http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550",
 		"author":{
@@ -104,7 +104,7 @@ const PipelineRun = `{
 	},
 	"commit":{
 		"id":"ec0a1bcd4580bfec3495674e412f4834ee2c2550",
-		"message":"Start gitlab-ci",
+		"message":"Start gitlab-ci\n",
 		"timestamp":"2019-04-17T20:38:43Z",
 		"url":"http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550",
 		"author":{
@@ -178,7 +178,7 @@ const PipelineFail = `{
 	},
 	"commit":{
 		"id":"ec0a1bcd4580bfec3495674e412f4834ee2c2550",
-		"message":"Start gitlab-ci",
+		"message":"Start gitlab-ci\n",
 		"timestamp":"2019-04-17T20:38:43Z",
 		"url":"http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550",
 		"author":{
@@ -252,7 +252,7 @@ const PipelineSuccess = `{
 	},
 	"commit":{
 		"id":"ec0a1bcd4580bfec3495674e412f4834ee2c2550",
-		"message":"Start gitlab-ci",
+		"message":"Start gitlab-ci\n",
 		"timestamp":"2019-04-17T20:38:43Z",
 		"url":"http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550",
 		"author":{

--- a/server/webhook/pipeline_test.go
+++ b/server/webhook/pipeline_test.go
@@ -32,7 +32,7 @@ var testDataPipeline = []testDataPipelineStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "pipeline", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) New pipeline by [root](http://my.gitlab.com/root) for [Start gitlab-ci](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
+			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) New pipeline by [root](http://my.gitlab.com/root) for Start gitlab-ci\n[View Commit](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
 			ToUsers:    []string{}, // No DM because user know he has launch a pipeline
 			ToChannels: []string{"channel1"},
 			From:       "root",
@@ -44,7 +44,7 @@ var testDataPipeline = []testDataPipelineStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "pipeline", Repository: "manland/subgroup/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook) New pipeline by [root](http://my.gitlab.com/root) for [Start gitlab-ci](http://localhost:3000/manland/subgroup/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
+			Message:    "[manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook) New pipeline by [root](http://my.gitlab.com/root) for Start gitlab-ci\n[View Commit](http://localhost:3000/manland/subgroup/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
 			ToUsers:    []string{}, // No DM because user know he has launch a pipeline
 			ToChannels: []string{"channel1"},
 			From:       "root",
@@ -56,12 +56,12 @@ var testDataPipeline = []testDataPipelineStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "pipeline", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Your pipeline has failed for [Start gitlab-ci](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
+			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Your pipeline has failed for Start gitlab-ci\n[View Commit](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "",
 		}, {
-			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Pipeline by [root](http://my.gitlab.com/root) fail for [Start gitlab-ci](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
+			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Pipeline by [root](http://my.gitlab.com/root) fail for Start gitlab-ci\n[View Commit](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
 			ToUsers:    []string{},
 			ToChannels: []string{},
 			From:       "root",
@@ -73,7 +73,7 @@ var testDataPipeline = []testDataPipelineStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "pipeline", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Pipeline by [root](http://my.gitlab.com/root) success for [Start gitlab-ci](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
+			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Pipeline by [root](http://my.gitlab.com/root) success for Start gitlab-ci\n[View Commit](http://localhost:3000/manland/webhook/commit/ec0a1bcd4580bfec3495674e412f4834ee2c2550)",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "root",


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Reformats pipeline messages to avoid wrapping commit message in link
that contains a new line.

Appropriate tests have been updated to reflect this change & the fact that GitLab adds newlines in their JSON webhook data for messages.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/135

