### PR TITLE
[GH-149] Replace # with ! for Merge Request references

### DIFF
--- a/server/webhook/merge_request.go
+++ b/server/webhook/merge_request.go
@@ -25,16 +25,16 @@ func (w *webhook) handleDMMergeRequest(event *gitlab.MergeEvent) ([]*HandleWebho
 	message := ""
 
 	if event.ObjectAttributes.State == "opened" && event.ObjectAttributes.Action == "open" {
-		message = fmt.Sprintf("[%s](%s) requested your review on [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+		message = fmt.Sprintf("[%s](%s) requested your review on [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
 	} else if event.ObjectAttributes.State == "closed" {
-		message = fmt.Sprintf("[%s](%s) closed your merge request [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+		message = fmt.Sprintf("[%s](%s) closed your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
 	} else if event.ObjectAttributes.State == "opened" && event.ObjectAttributes.Action == "reopen" {
-		message = fmt.Sprintf("[%s](%s) reopen your merge request [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+		message = fmt.Sprintf("[%s](%s) reopen your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
 	} else if event.ObjectAttributes.State == "opened" && event.ObjectAttributes.Action == "update" {
 		// TODO not enough check (opened/update) to say assigned to you...
-		message = fmt.Sprintf("[%s](%s) assigned you to merge request [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+		message = fmt.Sprintf("[%s](%s) assigned you to merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
 	} else if event.ObjectAttributes.State == "merged" && event.ObjectAttributes.Action == "merge" {
-		message = fmt.Sprintf("[%s](%s) merged your merge request [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+		message = fmt.Sprintf("[%s](%s) merged your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
 	}
 
 	if len(message) > 0 {
@@ -69,13 +69,13 @@ func (w *webhook) handleChannelMergeRequest(event *gitlab.MergeEvent) ([]*Handle
 
 	switch pr.Action {
 	case "open":
-		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s) new merge-request by [%s](%s) on [%s](%s)\n\n%s", pr.Title, repo.PathWithNamespace, pr.IID, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), pr.CreatedAt, pr.URL, pr.Description)
+		message = fmt.Sprintf("#### %s\n##### [%s!%v](%s) new merge-request by [%s](%s) on [%s](%s)\n\n%s", pr.Title, repo.PathWithNamespace, pr.IID, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), pr.CreatedAt, pr.URL, pr.Description)
 	case "merge":
-		message = fmt.Sprintf("[%s] Merge request [#%v %s](%s) was merged by [%s](%s)", repo.PathWithNamespace, pr.IID, pr.Title, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
+		message = fmt.Sprintf("[%s] Merge request [!%v %s](%s) was merged by [%s](%s)", repo.PathWithNamespace, pr.IID, pr.Title, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
 	case "close":
-		message = fmt.Sprintf("[%s] Merge request [#%v %s](%s) was closed by [%s](%s)", repo.PathWithNamespace, pr.IID, pr.Title, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
+		message = fmt.Sprintf("[%s] Merge request [!%v %s](%s) was closed by [%s](%s)", repo.PathWithNamespace, pr.IID, pr.Title, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
 	case "reopen":
-		message = fmt.Sprintf("[%s] Merge request [#%v %s](%s) was reopened by [%s](%s)", repo.PathWithNamespace, pr.IID, pr.Title, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
+		message = fmt.Sprintf("[%s] Merge request [!%v %s](%s) was reopened by [%s](%s)", repo.PathWithNamespace, pr.IID, pr.Title, pr.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
 	}
 
 	if len(message) > 0 {

--- a/server/webhook/merge_request_test.go
+++ b/server/webhook/merge_request_test.go
@@ -25,12 +25,12 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/webhook#4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
 			ToUsers:    []string{"manland"},
 			ToChannels: []string{},
 			From:       "root",
 		}, {
-			Message:    "#### Master\n##### [manland/webhook#4](http://localhost:3000/manland/webhook/merge_requests/4) new merge-request by [root](http://my.gitlab.com/root) on [2019-04-03 21:07:32 UTC](http://localhost:3000/manland/webhook/merge_requests/4)\n\ntest open merge request",
+			Message:    "#### Master\n##### [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4) new merge-request by [root](http://my.gitlab.com/root) on [2019-04-03 21:07:32 UTC](http://localhost:3000/manland/webhook/merge_requests/4)\n\ntest open merge request",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "root",
@@ -42,12 +42,12 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/subgroup/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/subgroup/webhook#4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4)",
+			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/subgroup/webhook!4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4)",
 			ToUsers:    []string{"manland"},
 			ToChannels: []string{},
 			From:       "root",
 		}, {
-			Message:    "#### Master\n##### [manland/subgroup/webhook#4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4) new merge-request by [root](http://my.gitlab.com/root) on [2019-04-03 21:07:32 UTC](http://localhost:3000/manland/subgroup/webhook/merge_requests/4)\n\ntest open merge request",
+			Message:    "#### Master\n##### [manland/subgroup/webhook!4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4) new merge-request by [root](http://my.gitlab.com/root) on [2019-04-03 21:07:32 UTC](http://localhost:3000/manland/subgroup/webhook/merge_requests/4)\n\ntest open merge request",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "root",
@@ -59,12 +59,12 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) closed your merge request [manland/webhook#4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[manland](http://my.gitlab.com/manland) closed your merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
 		}, {
-			Message:    "[manland/webhook] Merge request [#4 Master](http://localhost:3000/manland/webhook/merge_requests/4) was closed by [manland](http://my.gitlab.com/manland)",
+			Message:    "[manland/webhook] Merge request [!4 Master](http://localhost:3000/manland/webhook/merge_requests/4) was closed by [manland](http://my.gitlab.com/manland)",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "manland",
@@ -76,12 +76,12 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) reopen your merge request [manland/webhook#1](http://localhost:3000/manland/webhook/merge_requests/1)",
+			Message:    "[manland](http://my.gitlab.com/manland) reopen your merge request [manland/webhook!1](http://localhost:3000/manland/webhook/merge_requests/1)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
 		}, {
-			Message:    "[manland/webhook] Merge request [#1 Update README.md](http://localhost:3000/manland/webhook/merge_requests/1) was reopened by [manland](http://my.gitlab.com/manland)",
+			Message:    "[manland/webhook] Merge request [!1 Update README.md](http://localhost:3000/manland/webhook/merge_requests/1) was reopened by [manland](http://my.gitlab.com/manland)",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "manland",
@@ -91,7 +91,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 		fixture:         AssigneeMergeRequest,
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) assigned you to merge request [manland/webhook#4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[root](http://my.gitlab.com/root) assigned you to merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
 			ToUsers:    []string{"manland"},
 			ToChannels: []string{},
 			From:       "root",
@@ -103,12 +103,12 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) merged your merge request [manland/webhook#4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[manland](http://my.gitlab.com/manland) merged your merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
 		}, {
-			Message:    "[manland/webhook] Merge request [#4 Master](http://localhost:3000/manland/webhook/merge_requests/4) was merged by [manland](http://my.gitlab.com/manland)",
+			Message:    "[manland/webhook] Merge request [!4 Master](http://localhost:3000/manland/webhook/merge_requests/4) was merged by [manland](http://my.gitlab.com/manland)",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "manland",
@@ -120,12 +120,12 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) closed your merge request [manland/webhook#1](http://localhost:3000/manland/webhook/merge_requests/1)",
+			Message:    "[root](http://my.gitlab.com/root) closed your merge request [manland/webhook!1](http://localhost:3000/manland/webhook/merge_requests/1)",
 			ToUsers:    []string{}, //no assignee
 			ToChannels: []string{},
 			From:       "root",
 		}, {
-			Message:    "[manland/webhook] Merge request [#1 Update README.md](http://localhost:3000/manland/webhook/merge_requests/1) was closed by [root](http://my.gitlab.com/root)",
+			Message:    "[manland/webhook] Merge request [!1 Update README.md](http://localhost:3000/manland/webhook/merge_requests/1) was closed by [root](http://my.gitlab.com/root)",
 			ToUsers:    []string{},
 			ToChannels: []string{"channel1"},
 			From:       "root",
@@ -137,7 +137,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "issues", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/webhook#4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
 			ToUsers:    []string{"manland"},
 			ToChannels: []string{},
 			From:       "root",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This pull request replaces the `#` symbol for merge requests to use the correct prefix of `!` as defined in the Gitlab's [Special Gitlab References](https://docs.gitlab.com/ee/user/markdown.html#special-gitlab-references) documentation.

#### Ticket Link
Fixes #149

