### PR TITLE
[GH-163] Fix missing whitespace between commit message and commit link

### DIFF
--- a/server/webhook/push.go
+++ b/server/webhook/push.go
@@ -46,14 +46,16 @@ func (w *webhook) handleChannelPush(event *gitlab.PushEvent) ([]*HandleWebhook, 
 		return nil, nil
 	}
 
-	var message string
+	var plural string = "commits"
+
 	if event.TotalCommitsCount == 1 {
-		message = fmt.Sprintf("[%s](%s) has pushed %d commit to [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.TotalCommitsCount, event.Project.PathWithNamespace, event.Project.WebURL)
-	} else {
-		message = fmt.Sprintf("[%s](%s) has pushed %d commits to [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.TotalCommitsCount, event.Project.PathWithNamespace, event.Project.WebURL)
+		plural = "commit"
 	}
+
+	var message string = fmt.Sprintf("[%s](%s) has pushed %d %s to [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.TotalCommitsCount, plural, event.Project.PathWithNamespace, event.Project.WebURL)
+
 	for _, commit := range event.Commits {
-		message += fmt.Sprintf("\n%s[%s](%s)", commit.Message, "View Commit", commit.URL)
+		message += fmt.Sprintf("\n%s [%s](%s)", commit.Message, "View Commit", commit.URL)
 	}
 
 	toChannels := make([]string, 0)

--- a/server/webhook/push_test.go
+++ b/server/webhook/push_test.go
@@ -26,7 +26,7 @@ var testDataPush = []testDataPushStr{
 		}),
 		res: []*HandleWebhook{{
 			Message: "[manland](http://my.gitlab.com/manland) has pushed 1 commit to [manland/webhook](http://localhost:3000/manland/webhook)\n" +
-				"really cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)",
+				"really cool commit\n [View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)",
 			ToUsers:    []string{}, // No DM because user know he has push commits
 			ToChannels: []string{"channel1"},
 			From:       "manland",
@@ -39,7 +39,7 @@ var testDataPush = []testDataPushStr{
 		}),
 		res: []*HandleWebhook{{
 			Message: "[manland](http://my.gitlab.com/manland) has pushed 1 commit to [manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook)\n" +
-				"really cool commit\n[View Commit](http://localhost:3000/manland/subgroup/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)",
+				"really cool commit\n [View Commit](http://localhost:3000/manland/subgroup/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)",
 			ToUsers:    []string{}, // No DM because user know he has push commits
 			ToChannels: []string{"channel1"},
 			From:       "manland",
@@ -52,8 +52,8 @@ var testDataPush = []testDataPushStr{
 		}),
 		res: []*HandleWebhook{{
 			Message: "[manland](http://my.gitlab.com/manland) has pushed 2 commits to [manland/webhook](http://localhost:3000/manland/webhook)\n" +
-				"really cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)\n" +
-				"another cool commit\n[View Commit](http://localhost:3000/manland/webhook/commit/595f2a068cce60954565b224bc7c966c9e708cbf)",
+				"really cool commit\n [View Commit](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663)\n" +
+				"another cool commit\n [View Commit](http://localhost:3000/manland/webhook/commit/595f2a068cce60954565b224bc7c966c9e708cbf)",
 			ToUsers:    []string{}, // No DM because user know he has push commits
 			ToChannels: []string{"channel1"},
 			From:       "manland",


### PR DESCRIPTION
#### Summary
Fix missing whitespace between commit message and commit link for the push web hook.

#### Ticket Link
Resolves #163
