### PR TITLE
change webhook list and creation commands to show non-clickable links

### DIFF
--- a/server/command_test.go
+++ b/server/command_test.go
@@ -116,8 +116,7 @@ var listWebhookCommandTests = []webhookCommandTest{
 				WikiPageEvents:           false,
 			},
 		},
-		want: `
-http://yourURL/plugins/com.github.manland.mattermost-plugin-gitlab/webhook
+		want: "\n\n`http://yourURL/plugins/com.github.manland.mattermost-plugin-gitlab/webhook`" + `
 Triggers:
 * Push Events
 * Tag Push Events
@@ -141,12 +140,10 @@ Triggers:
 				PushEvents: true,
 			},
 		},
-		want: `
-http://yourURL/plugins/com.github.manland.mattermost-plugin-gitlab/webhook
+		want: "\n\n`http://yourURL/plugins/com.github.manland.mattermost-plugin-gitlab/webhook`" + `
 Triggers:
 * Push Events
-
-http://anotherURL
+` + "\n\n`http://anotherURL`" + `
 Triggers:
 * Push Events
 `,
@@ -169,8 +166,7 @@ Triggers:
 				WikiPageEvents:           false,
 			},
 		},
-		want: `
-http://yourURL/plugins/com.github.manland.mattermost-plugin-gitlab/webhook
+		want: "\n\n`http://yourURL/plugins/com.github.manland.mattermost-plugin-gitlab/webhook`" + `
 Triggers:
 * Push Events
 * Tag Push Events
@@ -276,23 +272,21 @@ var addWebhookCommandTests = []webhookCommandTest{
 	{
 		testName:   "Create project hook with defaults",
 		paramaters: []string{"add", "group/project"},
-		want:       "Webhook Created:\n\nhttps://example.com" + allTriggersFormated,
+		want:       "Webhook Created:\n\n\n`https://example.com`" + allTriggersFormated,
 		siteURL:    "https://example.com",
 		webhook:    exampleWebhookWithAlltriggers,
 	},
 	{
 		testName:   "Create project hook with all trigers",
 		paramaters: []string{"add", "group/project", "*"},
-		want:       "Webhook Created:\n\nhttps://example.com" + allTriggersFormated,
+		want:       "Webhook Created:\n\n\n`https://example.com`" + allTriggersFormated,
 		siteURL:    "https://example.com",
 		webhook:    exampleWebhookWithAlltriggers,
 	},
 	{
 		testName:   "Create project hook with explicit trigers",
 		paramaters: []string{"add", "group/project", "PushEvents,MergeRequestEvents"},
-		want: `Webhook Created:
-
-https://example.com
+		want: "Webhook Created:\n\n\n`https://example.com`" + `
 Triggers:
 * Push Events
 * Merge Request Events
@@ -307,7 +301,7 @@ Triggers:
 	{
 		testName:   "Create project hook with explicit URL",
 		paramaters: []string{"add", "group/project", "*", "https://anothersite.com"},
-		want:       "Webhook Created:\n\nhttps://anothersite.com" + allTriggersFormated,
+		want:       "Webhook Created:\n\n\n`https://anothersite.com`" + allTriggersFormated,
 		siteURL:    "https://example.com",
 		webhook: &gitlab.WebhookInfo{
 			URL:                      "https://anothersite.com",
@@ -327,14 +321,14 @@ Triggers:
 	{
 		testName:   "Create project hook with explicit token",
 		paramaters: []string{"add", "group/project", "*", "https://example.com", "1234abcd"},
-		want:       "Webhook Created:\n\nhttps://example.com" + allTriggersFormated,
+		want:       "Webhook Created:\n\n\n`https://example.com`" + allTriggersFormated,
 		siteURL:    "https://example.com",
 		webhook:    exampleWebhookWithAlltriggers,
 	},
 	{
 		testName:   "Create Group hook with defaults",
 		paramaters: []string{"add", "group"},
-		want:       "Webhook Created:\n\nhttps://example.com" + allTriggersFormated,
+		want:       "Webhook Created:\n\n\n`https://example.com`" + allTriggersFormated,
 		siteURL:    "https://example.com",
 		scope:      "group",
 		webhook:    exampleWebhookWithAlltriggers,

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -141,7 +141,7 @@ func (w *WebhookInfo) String() string {
 		formatedTriggers += "* Wiki Page Events\n"
 	}
 
-	return "\n" + w.URL + "\n" + formatedTriggers
+	return "\n\n`" + w.URL + "`\n" + formatedTriggers
 }
 
 func getProjectHookInfo(hook *internGitlab.ProjectHook) *WebhookInfo {


### PR DESCRIPTION
#### Summary
This PR changes webhook list and create commands to show non-clickable links.

Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/196

### Screenshots

#### create command
Before
![mm_create_before](https://user-images.githubusercontent.com/45372453/90359302-d72cc200-e058-11ea-8184-30d9ac58231f.png)
After
![mm_create_after](https://user-images.githubusercontent.com/45372453/90359311-e3188400-e058-11ea-8860-70f71347b57e.png)


#### list command
Before:
![mm_list_before](https://user-images.githubusercontent.com/45372453/90359202-86b56480-e058-11ea-9ca9-c9555ba945fd.png)
After:
![mm_list_after](https://user-images.githubusercontent.com/45372453/90359218-98970780-e058-11ea-8fc3-e96f14894b49.png)



