### PR TITLE
[GH-184]: Use UserUsername in Link, Fixes GitLab id storage

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -172,7 +172,11 @@ func (p *Plugin) completeConnectUserToGitlab(w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := p.storeGitlabToUserIDMapping(userInfo.GitlabUsername, userID); err != nil {
-		p.API.LogError("can't store user id mapping", "err", err.Error())
+		p.API.LogError("can't store GitLab to user id mapping", "err", err.Error())
+	}
+
+	if err := p.storeGitlabIDToUserIDMapping(userInfo.GitlabUsername, userInfo.GitlabUserID); err != nil {
+		p.API.LogError("can't store GitLab to GitLab id mapping", "err", err.Error())
 	}
 
 	// Post intro post

--- a/server/command.go
+++ b/server/command.go
@@ -208,14 +208,16 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 		case SettingNotifications:
 			if value {
 				if err := p.storeGitlabToUserIDMapping(info.GitlabUsername, info.UserID); err != nil {
-					p.API.LogError("can't store GitLab user id mapping", "err", err.Error())
+					p.API.LogError("can't store GitLab to user id mapping", "err", err.Error())
 					return p.getCommandResponse(args, "Unknown error please retry or ask to an administrator to look at logs"), nil
 				}
-			} else {
-				if err := p.API.KVDelete(info.GitlabUsername + GitlabUsernameKey); err != nil {
-					p.API.LogError("can't delete GitLab username in kvstore", "err", err.Error())
+				if err := p.storeGitlabIDToUserIDMapping(info.GitlabUsername, info.GitlabUserID); err != nil {
+					p.API.LogError("can't store GitLab to GitLab id mapping", "err", err.Error())
 					return p.getCommandResponse(args, "Unknown error please retry or ask to an administrator to look at logs"), nil
 				}
+			} else if err := p.API.KVDelete(info.GitlabUsername + GitlabUsernameKey); err != nil {
+				p.API.LogError("can't delete GitLab username in kvstore", "err", err.Error())
+				return p.getCommandResponse(args, "Unknown error please retry or ask to an administrator to look at logs"), nil
 			}
 			info.Settings.Notifications = value
 		case SettingReminders:

--- a/server/command.go
+++ b/server/command.go
@@ -215,7 +215,7 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 					p.API.LogError("can't store GitLab to GitLab id mapping", "err", err.Error())
 					return p.getCommandResponse(args, "Unknown error please retry or ask to an administrator to look at logs"), nil
 				}
-			} else if err := p.API.KVDelete(info.GitlabUsername + GitlabUsernameKey); err != nil {
+			} else if err := p.deleteGitlabToUserIDMapping(info.GitlabUsername); err != nil {
 				p.API.LogError("can't delete GitLab username in kvstore", "err", err.Error())
 				return p.getCommandResponse(args, "Unknown error please retry or ask to an administrator to look at logs"), nil
 			}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -166,7 +166,11 @@ func (p *Plugin) storeGitlabToUserIDMapping(gitlabUsername, userID string) error
 	if err := p.API.KVSet(gitlabUsername+GitlabUsernameKey, []byte(userID)); err != nil {
 		return fmt.Errorf("encountered error saving GitLab username mapping")
 	}
-	if err := p.API.KVSet(userID+GitlabIDUsernameKey, []byte(gitlabUsername)); err != nil {
+	return nil
+}
+
+func (p *Plugin) storeGitlabIDToUserIDMapping(gitlabUsername string, gitlabID int) error {
+	if err := p.API.KVSet(fmt.Sprintf("%d", gitlabID)+GitlabIDUsernameKey, []byte(gitlabUsername)); err != nil {
 		return fmt.Errorf("encountered error saving GitLab id mapping")
 	}
 	return nil

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -140,6 +140,13 @@ func (p *Plugin) storeGitlabUserInfo(info *gitlab.UserInfo) error {
 	return nil
 }
 
+func (p *Plugin) deleteGitlabUserInfo(userID string) error {
+	if err := p.API.KVDelete(userID + GitlabTokenKey); err != nil {
+		return fmt.Errorf("encountered error deleting GitLab user info: %w", err)
+	}
+	return nil
+}
+
 func (p *Plugin) getGitlabUserInfoByMattermostID(userID string) (*gitlab.UserInfo, *APIErrorResponse) {
 	config := p.getConfiguration()
 
@@ -164,14 +171,28 @@ func (p *Plugin) getGitlabUserInfoByMattermostID(userID string) (*gitlab.UserInf
 
 func (p *Plugin) storeGitlabToUserIDMapping(gitlabUsername, userID string) error {
 	if err := p.API.KVSet(gitlabUsername+GitlabUsernameKey, []byte(userID)); err != nil {
-		return fmt.Errorf("encountered error saving GitLab username mapping")
+		return fmt.Errorf("encountered error saving GitLab username mapping: %w", err)
 	}
 	return nil
 }
 
 func (p *Plugin) storeGitlabIDToUserIDMapping(gitlabUsername string, gitlabID int) error {
-	if err := p.API.KVSet(fmt.Sprintf("%d", gitlabID)+GitlabIDUsernameKey, []byte(gitlabUsername)); err != nil {
-		return fmt.Errorf("encountered error saving GitLab id mapping")
+	if err := p.API.KVSet(fmt.Sprintf("%d%s", gitlabID, GitlabIDUsernameKey), []byte(gitlabUsername)); err != nil {
+		return fmt.Errorf("encountered error saving GitLab id mapping: %w", err)
+	}
+	return nil
+}
+
+func (p *Plugin) deleteGitlabToUserIDMapping(gitlabUsername string) error {
+	if err := p.API.KVDelete(gitlabUsername + GitlabUsernameKey); err != nil {
+		return fmt.Errorf("encountered error deleting GitLab username mapping: %w", err)
+	}
+	return nil
+}
+
+func (p *Plugin) deleteGitlabIDToUserIDMapping(gitlabID int) error {
+	if err := p.API.KVDelete(fmt.Sprintf("%d%s", gitlabID, GitlabIDUsernameKey)); err != nil {
+		return fmt.Errorf("encountered error deleting GitLab id mapping: %w", err)
 	}
 	return nil
 }
@@ -202,14 +223,14 @@ func (p *Plugin) disconnectGitlabAccount(userID string) {
 		return
 	}
 
-	if err := p.API.KVDelete(userID + GitlabTokenKey); err != nil {
-		p.API.LogError("can't delete token in store", "err", err.DetailedError, "userId", userID)
+	if err := p.deleteGitlabUserInfo(userID); err != nil {
+		p.API.LogError("can't delete token in store", "err", err.Error, "userId", userID)
 	}
-	if err := p.API.KVDelete(userInfo.GitlabUsername + GitlabUsernameKey); err != nil {
-		p.API.LogError("can't delete username in store", "err", err.DetailedError, "username", userInfo.GitlabUsername)
+	if err := p.deleteGitlabToUserIDMapping(userInfo.GitlabUsername); err != nil {
+		p.API.LogError("can't delete username in store", "err", err.Error, "username", userInfo.GitlabUsername)
 	}
-	if err := p.API.KVDelete(fmt.Sprintf("%d%s", userInfo.GitlabUserID, GitlabIDUsernameKey)); err != nil {
-		p.API.LogError("can't delete user id in sotre", "err", err.DetailedError, "id", userInfo.GitlabUserID)
+	if err := p.deleteGitlabIDToUserIDMapping(userInfo.GitlabUserID); err != nil {
+		p.API.LogError("can't delete user id in store", "err", err.Error, "id", userInfo.GitlabUserID)
 	}
 
 	if user, err := p.API.GetUser(userID); err == nil && user.Props != nil && len(user.Props["git_user"]) > 0 {

--- a/server/webhook/push.go
+++ b/server/webhook/push.go
@@ -38,7 +38,7 @@ func (w *webhook) handleDMPush(event *gitlab.PushEvent) ([]*HandleWebhook, error
 }
 
 func (w *webhook) handleChannelPush(event *gitlab.PushEvent) ([]*HandleWebhook, error) {
-	senderGitlabUsername := event.UserName
+	senderGitlabUsername := event.UserUsername
 	repo := event.Project
 	res := []*HandleWebhook{}
 

--- a/server/webhook/tag.go
+++ b/server/webhook/tag.go
@@ -39,7 +39,7 @@ func (w *webhook) handleDMTag(event *gitlab.TagEvent) ([]*HandleWebhook, error) 
 }
 
 func (w *webhook) handleChannelTag(event *gitlab.TagEvent) ([]*HandleWebhook, error) {
-	senderGitlabUsername := event.UserName
+	senderGitlabUsername := w.gitlabRetreiver.GetUsernameByID(event.UserID)
 	repo := event.Project
 	tagNames := strings.Split(event.Ref, "/")
 	tagName := tagNames[len(tagNames)-1]


### PR DESCRIPTION
#### Summary

This PR aims to solve the issue with broken account links in GitLab notifications.
It basically replaces `UserName` with `UserUserName` to use the actual GitLab username instead of the displayed name in the link. While fixing that, it was also required to fix the storage of the GitLab user id. Before this commit, `userID` and `GitlabUserID` have been mixed up, so that `GetUsernameByID` wasn´t returning the correct username.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/184
