### PR TITLE
Programmatically generate tag URL

### DIFF
--- a/server/webhook/tag.go
+++ b/server/webhook/tag.go
@@ -24,7 +24,7 @@ func (w *webhook) handleDMTag(event *gitlab.TagEvent) ([]*HandleWebhook, error) 
 	handlers := []*HandleWebhook{}
 	tagNames := strings.Split(event.Ref, "/")
 	tagName := tagNames[len(tagNames)-1]
-	URL := fmt.Sprintf("%s/-/tags/%s", event.Repository.WebURL, tagName)
+	URL := fmt.Sprintf("%s/-/tags/%s", event.Project.WebURL, tagName)
 
 	if mention := w.handleMention(mentionDetails{
 		senderUsername:    senderGitlabUsername,
@@ -44,7 +44,7 @@ func (w *webhook) handleChannelTag(event *gitlab.TagEvent) ([]*HandleWebhook, er
 	repo := event.Project
 	tagNames := strings.Split(event.Ref, "/")
 	tagName := tagNames[len(tagNames)-1]
-	URL := fmt.Sprintf("%s/-/tags/%s", event.Repository.URL, tagName)
+	URL := fmt.Sprintf("%s/-/tags/%s", repo.WebURL, tagName)
 	res := []*HandleWebhook{}
 
 	message := fmt.Sprintf("[%s](%s) New tag [%s](%s) by [%s](%s): %s", repo.PathWithNamespace, repo.WebURL, tagName, URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Message)

--- a/server/webhook/tag.go
+++ b/server/webhook/tag.go
@@ -24,12 +24,13 @@ func (w *webhook) handleDMTag(event *gitlab.TagEvent) ([]*HandleWebhook, error) 
 	handlers := []*HandleWebhook{}
 	tagNames := strings.Split(event.Ref, "/")
 	tagName := tagNames[len(tagNames)-1]
+	URL := fmt.Sprintf("%s/-/tags/%s", event.Repository.WebURL, tagName)
 
 	if mention := w.handleMention(mentionDetails{
 		senderUsername:    senderGitlabUsername,
 		pathWithNamespace: event.Project.PathWithNamespace,
 		IID:               tagName,
-		URL:               event.Commits[0].URL,
+		URL:               URL,
 		body:              event.Message,
 	}); mention != nil {
 		handlers = append(handlers, mention)
@@ -43,9 +44,10 @@ func (w *webhook) handleChannelTag(event *gitlab.TagEvent) ([]*HandleWebhook, er
 	repo := event.Project
 	tagNames := strings.Split(event.Ref, "/")
 	tagName := tagNames[len(tagNames)-1]
+	URL := fmt.Sprintf("%s/-/tags/%s", event.Repository.URL, tagName)
 	res := []*HandleWebhook{}
 
-	message := fmt.Sprintf("[%s](%s) New tag [%s](%s) by [%s](%s): %s", repo.PathWithNamespace, repo.WebURL, tagName, event.Commits[0].URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Message)
+	message := fmt.Sprintf("[%s](%s) New tag [%s](%s) by [%s](%s): %s", repo.PathWithNamespace, repo.WebURL, tagName, URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Message)
 
 	toChannels := make([]string, 0)
 	namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)

--- a/server/webhook/tag_test.go
+++ b/server/webhook/tag_test.go
@@ -26,7 +26,7 @@ var testDataTag = []testDataTagStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "tag", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) New tag [tag1](http://localhost:3000/manland/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663) by [manland](http://my.gitlab.com/manland): Really beautiful tag",
+			Message:    "[manland/webhook](http://localhost:3000/manland/webhook) New tag [tag1](http://localhost:3000/manland/webhook/-/tags/tag1) by [manland](http://my.gitlab.com/manland): Really beautiful tag",
 			ToUsers:    []string{}, // No DM because user know he has created a tag
 			ToChannels: []string{"channel1"},
 			From:       "manland",
@@ -39,7 +39,7 @@ var testDataTag = []testDataTagStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "tag", Repository: "manland/subgroup/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook) New tag [tag1](http://localhost:3000/manland/subgroup/webhook/commit/c30217b62542c586fdbadc7b5ee762bfdca10663) by [manland](http://my.gitlab.com/manland): Really beautiful tag",
+			Message:    "[manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook) New tag [tag1](http://localhost:3000/manland/subgroup/webhook/-/tags/tag1) by [manland](http://my.gitlab.com/manland): Really beautiful tag",
 			ToUsers:    []string{}, // No DM because user know he has created a tag
 			ToChannels: []string{"channel1"},
 			From:       "manland",


### PR DESCRIPTION
#### Summary
Instead of using the commit list of the tag, which might be empty, programmatically generate the tag URL.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/228