### PR TITLE
fix the link to get the pending reviews

### DIFF
--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
@@ -147,7 +147,7 @@ export default class SidebarButtons extends React.PureComponent {
                     overlay={<Tooltip id='reviewTooltip'>Merge requests needing review</Tooltip>}
                 >
                     <a
-                        href={baseURL + orgQuery + '/merge_requests?assignee_username=' + this.props.username}
+                        href={baseURL + orgQuery + '/merge_requests?reviewer_username=' + this.props.username}
                         target='_blank'
                         rel='noopener noreferrer'
                         style={button}


### PR DESCRIPTION

#### Summary
Using the gitlab in our community deployment notice that it did not show any MR that I need to review, checking closely notice that we were using a wrong filter. this PR update the filter and using that I was able to see my pending MR to review


#### Ticket Link
n/a

