### PR TITLE
[GH-195] Send notification to channel when issue gets reopened

### DIFF
--- a/server/webhook/issue.go
+++ b/server/webhook/issue.go
@@ -75,6 +75,8 @@ func (w *webhook) handleChannelIssue(event *gitlab.IssueEvent) ([]*HandleWebhook
 		message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n###### new issue by [%s](%s) on [%s](%s)\n\n%s", issue.Title, repo.PathWithNamespace, issue.IID, issue.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), issue.CreatedAt, issue.URL, issue.Description)
 	case actionClose:
 		message = fmt.Sprintf("[%s] Issue [%s](%s) closed by [%s](%s)", repo.PathWithNamespace, issue.Title, issue.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
+	case actionReopen:
+		message = fmt.Sprintf("[%s] Issue [%s](%s) reopened by [%s](%s)", repo.PathWithNamespace, issue.Title, issue.URL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername))
 	case actionUpdate:
 		if len(event.Changes.Labels.Current) > 0 && !sameLabels(event.Changes.Labels.Current, event.Changes.Labels.Previous) {
 			message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n###### issue labeled `%s` by [%s](%s) on [%s](%s)\n\n%s", issue.Title, repo.PathWithNamespace, issue.IID, issue.URL, labelToString(event.Changes.Labels.Current), event.User.Username, event.User.WebsiteURL, issue.UpdatedAt, issue.URL, issue.Description)

--- a/server/webhook/issue_test.go
+++ b/server/webhook/issue_test.go
@@ -83,7 +83,7 @@ var testDataIssue = []testDataIssueStr{
 			From:       "manland",
 		}},
 	}, {
-		testTitle: "manland reopen issue of root and channel is not notified",
+		testTitle: "manland reopen issue of root and display in channel",
 		fixture:   ReopenIssue,
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
 			{ChannelID: "channel1", CreatorID: "1", Features: "issues", Repository: "manland/webhook"},
@@ -92,7 +92,12 @@ var testDataIssue = []testDataIssueStr{
 			Message: "[manland](http://my.gitlab.com/manland) reopened your issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
 			ToUsers: []string{"root"},
 			From:    "manland",
-		}}, // no channel message because not listen to reopen action
+		}, {
+			Message:    "[manland/webhook] Issue [test new issue](http://localhost:3000/manland/webhook/issues/1) reopened by [manland](http://my.gitlab.com/manland)",
+			ToUsers:    []string{},
+			ToChannels: []string{"channel1"},
+			From:       "manland",
+		}},
 	},
 }
 


### PR DESCRIPTION
#### Summary
Send notification to channel when the issue gets reopened.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/195
