### PR TITLE
`npm install --verbose` to avoid CircleCI timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 ## Ensures NPM dependencies are installed without having to run this all the time.
 webapp/node_modules: $(wildcard webapp/package.json)
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && $(NPM) install
+	cd webapp && $(NPM) install --verbose
 	touch $@
 endif
 


### PR DESCRIPTION
#### Summary

There is currently an issue with plugin projects, where CI will timeout during `npm install`. There is an issue with fetching dependencies from GitHub, which is causing this step to take longer than usual. Since CircleCI times out after 10 minutes of no console output, this is causing CI to fail for all webapp plugins.

This PR makes it so use the `--verbose` flag, so the command will have intermediate output, making it so CircleCI does not cancel the build. There is another suggested solution of editing the git config with `git config --global url."ssh://git@".insteadOf git://`, but we have decided to go with the `--verbose` approach instead.

More context here:
https://community-daily.mattermost.com/core/pl/ckmtk65jqjr6p8ahmrk9ggu1gh
https://community-daily.mattermost.com/core/pl/h3gdpbm5gpdai8xxmk1jc4k3ro

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-44776
