### PR TITLE
Release 1.5.2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "GitLab plugin for Mattermost.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-gitlab",
     "support_url": "https://github.com/mattermost/mattermost-plugin-gitlab/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-gitlab/releases/tag/v1.5.1",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-gitlab/releases/tag/v1.5.2",
     "icon_path": "assets/icon.svg",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "min_server_version": "6.5.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary

This release is meant to deliver the updates for the ReactDOM update effort, and resolve the issue with CGO in the 3.2.1 release.

#### Ticket Link

https://github.com/mattermost/mattermost-plugin-gitlab/issues/338