### PR TITLE
Fix path namespace for Job event handling

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -655,7 +655,6 @@ func (p *Plugin) pipelineRunCommand(ctx context.Context, namespace, ref, channel
 	txt += fmt.Sprintf("**Ref**: %s\n", pipelineInfo.Ref)
 	txt += fmt.Sprintf("**Triggered By**: %s\n", pipelineInfo.User)
 	txt += fmt.Sprintf("**Visit pipeline [here](%s)** \n\n", pipelineInfo.WebURL)
-	txt += "*This channel automatically subscribed to pipeline updates*"
 	return txt
 }
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -120,7 +120,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		handlers, errHandler = p.WebhookHandler.HandlePipeline(ctx, event)
 	case *gitlabLib.JobEvent:
 		repoPrivate = event.Repository.Visibility == gitlabLib.PrivateVisibility
-		pathWithNamespace = event.Repository.PathWithNamespace
+		pathWithNamespace = event.ProjectName
 		fromUser = event.User.Name
 		handlers, errHandler = p.WebhookHandler.HandleJobs(ctx, event)
 	case *gitlabLib.TagEvent:

--- a/server/webhook/jobs.go
+++ b/server/webhook/jobs.go
@@ -38,14 +38,17 @@ func (w *webhook) handleChannelJob(ctx context.Context, event *gitlab.JobEvent) 
 	default:
 		return res, nil
 	}
-	namespace, project := normalizeNamespacedProjectByHomepage(event.Repository.Homepage)
-	fullNamespacePath := fmt.Sprintf("%s/%s", namespace, project)
-	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Repository.HTTPURL)
+	namespaceMetadata, err := normalizeNamespacedProjectByHomepage(event.Repository.Homepage)
+	if err != nil {
+		return nil, err
+	}
+	fullNamespacePath := fmt.Sprintf("%s/%s", namespaceMetadata.Namespace, namespaceMetadata.Project)
+	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Repository.GitHTTPURL)
 	message += fmt.Sprintf("**Triggered By**: %s\n", senderGitlabUsername)
 	message += fmt.Sprintf("**Visit job [here](%s)** \n", w.gitlabRetreiver.GetJobURL(fullNamespacePath, event.BuildID))
 	toChannels := make([]string, 0)
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-		ctx, namespace, project,
+		ctx, namespaceMetadata.Namespace, namespaceMetadata.Project,
 		repo.Visibility == gitlab.PublicVisibility,
 	)
 	for _, sub := range subs {

--- a/server/webhook/jobs.go
+++ b/server/webhook/jobs.go
@@ -38,11 +38,12 @@ func (w *webhook) handleChannelJob(ctx context.Context, event *gitlab.JobEvent) 
 	default:
 		return res, nil
 	}
-	message += fmt.Sprintf("**Repository**: [%s](%s)\n", event.ProjectName, event.Repository.GitHTTPURL)
+	namespace, project := normalizeNamespacedProjectByHomepage(event.Repository.Homepage)
+	fullNamespacePath := fmt.Sprintf("%s/%s", namespace, project)
+	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Repository.GitHTTPURL)
 	message += fmt.Sprintf("**Triggered By**: %s\n", senderGitlabUsername)
-	message += fmt.Sprintf("**Visit job [here](%s)** \n", w.gitlabRetreiver.GetJobURL(event.ProjectName, event.BuildID))
+	message += fmt.Sprintf("**Visit job [here](%s)** \n", w.gitlabRetreiver.GetJobURL(fullNamespacePath, event.BuildID))
 	toChannels := make([]string, 0)
-	namespace, project := normalizeNamespacedProject(event.ProjectName)
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
 		ctx, namespace, project,
 		repo.Visibility == gitlab.PublicVisibility,

--- a/server/webhook/jobs.go
+++ b/server/webhook/jobs.go
@@ -40,7 +40,7 @@ func (w *webhook) handleChannelJob(ctx context.Context, event *gitlab.JobEvent) 
 	}
 	namespace, project := normalizeNamespacedProjectByHomepage(event.Repository.Homepage)
 	fullNamespacePath := fmt.Sprintf("%s/%s", namespace, project)
-	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Repository.GitHTTPURL)
+	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Repository.HTTPURL)
 	message += fmt.Sprintf("**Triggered By**: %s\n", senderGitlabUsername)
 	message += fmt.Sprintf("**Visit job [here](%s)** \n", w.gitlabRetreiver.GetJobURL(fullNamespacePath, event.BuildID))
 	toChannels := make([]string, 0)

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -165,6 +165,15 @@ func normalizeNamespacedProject(pathWithNamespace string) (namespace string, pro
 	return strings.Join(splits[:len(splits)-1], "/"), splits[len(splits)-1]
 }
 
+// normalizeNamespacedProjectByHomepage converts data from web hooks to format expected by our plugin.
+func normalizeNamespacedProjectByHomepage(homapge string) (namespace string, project string) {
+	splits := strings.Split(homapge, "/")
+	if len(splits) < 2 {
+		return "", ""
+	}
+	return strings.Join(splits[len(splits)-2:4], "/"), splits[len(splits)-1]
+}
+
 func sanitizeDescription(description string) string {
 	var policy = bluemonday.StrictPolicy()
 	policy.SkipElementsContent("details")

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -3,7 +3,10 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-gitlab/server/subscription"
 
@@ -165,13 +168,26 @@ func normalizeNamespacedProject(pathWithNamespace string) (namespace string, pro
 	return strings.Join(splits[:len(splits)-1], "/"), splits[len(splits)-1]
 }
 
+type namespaceProjectMetadata struct {
+	Namespace string
+	Project   string
+}
+
 // normalizeNamespacedProjectByHomepage converts data from web hooks to format expected by our plugin.
-func normalizeNamespacedProjectByHomepage(homepage string) (namespace string, project string) {
-	splits := strings.Split(homepage, "/")
-	if len(splits) < 4 {
-		return "", ""
+func normalizeNamespacedProjectByHomepage(homepage string) (*namespaceProjectMetadata, error) {
+	u, err := url.Parse(homepage)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse homepage URL")
 	}
-	return strings.Join(splits[len(splits)-2:4], "/"), splits[len(splits)-1]
+	splits := strings.Split(u.Path, "/")
+	if len(splits) < 2 {
+		return nil, errors.New("")
+	}
+
+	return &namespaceProjectMetadata{
+		Namespace: strings.Join(splits[1:len(splits)-1], "/"),
+		Project:   splits[len(splits)-1],
+	}, nil
 }
 
 func sanitizeDescription(description string) string {

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -166,9 +166,9 @@ func normalizeNamespacedProject(pathWithNamespace string) (namespace string, pro
 }
 
 // normalizeNamespacedProjectByHomepage converts data from web hooks to format expected by our plugin.
-func normalizeNamespacedProjectByHomepage(homapge string) (namespace string, project string) {
-	splits := strings.Split(homapge, "/")
-	if len(splits) < 2 {
+func normalizeNamespacedProjectByHomepage(homepage string) (namespace string, project string) {
+	splits := strings.Split(homepage, "/")
+	if len(splits) < 4 {
 		return "", ""
 	}
 	return strings.Join(splits[len(splits)-2:4], "/"), splits[len(splits)-1]

--- a/server/webhook/webhook_test.go
+++ b/server/webhook/webhook_test.go
@@ -84,3 +84,36 @@ func TestNormalizeNamespacedProject(t *testing.T) {
 		})
 	}
 }
+
+var testDataNormalizeNamespacedProjectByHomepage = []testDataNormalizeNamespacedProjectStr{
+	{
+		Title:                  "homepage with group",
+		InputPathWithNamespace: "http://test.url/group/project",
+		ExpectedNamespace:      "group",
+		ExpectedProject:        "project",
+	},
+	{
+		Title:                  "homepage with subgroup",
+		InputPathWithNamespace: "http://test.url/group/subgroup/project",
+		ExpectedNamespace:      "group/subgroup",
+		ExpectedProject:        "project",
+	},
+	{
+		Title:                  "homepage with subgroup of a subgroup",
+		InputPathWithNamespace: "http://test.url/group/subgroup/subgroup/project",
+		ExpectedNamespace:      "group/subgroup/subgroup",
+		ExpectedProject:        "project",
+	},
+}
+
+func TestNormalizeNamespacedProjectByHomePate(t *testing.T) {
+	t.Parallel()
+	for _, test := range testDataNormalizeNamespacedProjectByHomepage {
+		t.Run(test.Title, func(t *testing.T) {
+			namespaceMetadata, err := normalizeNamespacedProjectByHomepage(test.InputPathWithNamespace)
+			assert.NoError(t, err)
+			assert.Equal(t, test.ExpectedNamespace, namespaceMetadata.Namespace)
+			assert.Equal(t, test.ExpectedProject, namespaceMetadata.Project)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
The repository data are not included in the `JobEvent` and we can get the namespace only by the `event.ProjectName` field. This field doesn't match always the real url of the combinations `[group]/[repo]`

