### PR TITLE
Set request context timeout to 30 seconds for plugin http endpoints

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -28,7 +28,7 @@ import (
 const (
 	APIErrorIDNotConnected = "not_connected"
 
-	requestTimeout = 5 * time.Second
+	requestTimeout = 30 * time.Second
 )
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Summary

Similar to https://github.com/mattermost/mattermost-plugin-github/pull/579

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/345