### PR TITLE
Anchor the appsbar icon to SiteURL

### DIFF
--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
 import SidebarHeader from './components/sidebar_header';
 import TeamSidebar from './components/team_sidebar';
 import RHSSidebar from './components/rhs_sidebar';
@@ -69,7 +71,9 @@ class PluginClass {
 
         // App Bar icon
         if (registry.registerAppBarComponent) {
-            const iconURL = `/plugins/${id}/public/app-bar-icon.png`;
+            const config = getConfig(store.getState());
+            const siteUrl = (config && config.SiteURL) || '';
+            const iconURL = `${siteUrl}/plugins/${id}/public/app-bar-icon.png`;
             registry.registerAppBarComponent(iconURL, boundToggleRHSAction, 'GitLab');
         }
     }


### PR DESCRIPTION
#### Summary
This ensures the icon can be correctly loaded when a subpath is configured and the application isn't running at the root.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-plugin-gitlab/issues/343
