### PR TITLE
Point re-usable workflows to standard version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   plugin-cd:
-    uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@1a3d181953ab3e64bc12d7e3709cb619ab0ddb80
+    uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   plugin-ci:
-    uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@1a3d181953ab3e64bc12d7e3709cb619ab0ddb80
+    uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
     secrets: inherit


### PR DESCRIPTION
#### Summary
We are moving to use the changes of action-workflows repository to point the right changes and codebase.
