### PR TITLE
Add migration to send users message to reconnect on plugin startup

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -43,14 +43,14 @@ const commandHelp = `* |/gitlab connect| - Connect your Mattermost account to yo
 	 * |*| - or missing defaults to all with SSL verification enabled
 	 * *noSSL - all triggers with SSL verification not enabled.
 	 * PushEvents
-	 * TagPushEvents 
-	 * Comments 
-	 * ConfidentialComments 
+	 * TagPushEvents
+	 * Comments
+	 * ConfidentialComments
 	 * IssuesEvents
-	 * ConfidentialIssuesEvents 
-	 * MergeRequestsEvents 
-	 * JobEvents 
-	 * PipelineEvents 
+	 * ConfidentialIssuesEvents
+	 * MergeRequestsEvents
+	 * JobEvents
+	 * PipelineEvents
 	 * WikiPageEvents
 	 * SSLverification
   * |url| is the URL that will be called when triggered. Defaults to this plugins URL
@@ -64,6 +64,7 @@ const (
 	unknownActionMessage              = "Unknown action, please use `/gitlab help` to see all actions available."
 	newWebhookEmptySiteURLmessage     = "Unable to create webhook. The Mattermot Site URL is not set. " +
 		"Set it in the Admin Console or rerun /gitlab webhook add group/project URL including the desired URL."
+	gitlabConnectMessage = "[Click here to link your GitLab account.](%s/plugins/%s/oauth/connect)"
 )
 
 const (
@@ -175,7 +176,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			return p.getCommandResponse(args, "Encountered an error connecting to GitLab."), nil
 		}
 
-		resp := p.getCommandResponse(args, fmt.Sprintf("[Click here to link your GitLab account.](%s/plugins/%s/oauth/connect)", *config.ServiceSettings.SiteURL, manifest.Id))
+		resp := p.getCommandResponse(args, fmt.Sprintf(gitlabConnectMessage, *config.ServiceSettings.SiteURL, manifest.Id))
 		return resp, nil
 	}
 

--- a/server/oauth_migration.go
+++ b/server/oauth_migration.go
@@ -86,7 +86,7 @@ func (p *Plugin) notifyAllConnectedUsersToReconnect() error {
 	numErrors := 0
 	for _, key := range allKeys {
 		index := strings.Index(key, GitlabTokenKey)
-		userID := key[0:index]
+		userID := key[:index]
 
 		var logError = func(msg string, err error) {
 			numErrors++

--- a/server/oauth_migration.go
+++ b/server/oauth_migration.go
@@ -38,15 +38,25 @@ func (p *Plugin) checkAndPerformOAuthTokenMigration() error {
 		return nil
 	}
 
-	_, _ = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusInProgress)
+	_, err = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusInProgress)
+	if err != nil {
+		p.client.Log.Warn("error setting migration status to "+oauthMigrationStatusInProgress, "error", err.Error())
+	}
 
 	err = p.notifyAllConnectedUsersToReconnect()
 	if err != nil {
-		_, _ = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusError)
+		_, kvErr := p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusError)
+		if kvErr != nil {
+			p.client.Log.Warn("error setting migration status to "+oauthMigrationStatusError, "error", err.Error())
+		}
+
 		return err
 	}
 
-	_, _ = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusComplete)
+	_, err = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusComplete)
+	if err != nil {
+		p.client.Log.Warn("error setting migration status to "+oauthMigrationStatusComplete, "error", err.Error())
+	}
 
 	return nil
 }

--- a/server/oauth_migration.go
+++ b/server/oauth_migration.go
@@ -63,9 +63,10 @@ func (p *Plugin) checkAndPerformOAuthTokenMigration() error {
 
 func (p *Plugin) notifyAllConnectedUsersToReconnect() error {
 	allKeys := []string{}
+	perPage := 100
 	page := 0
 	for {
-		keys, err := p.client.KV.ListKeys(page, 100)
+		keys, err := p.client.KV.ListKeys(page, perPage)
 		if err != nil {
 			return errors.Wrap(err, "error listing keys for connected users")
 		}
@@ -82,6 +83,11 @@ func (p *Plugin) notifyAllConnectedUsersToReconnect() error {
 		}
 
 		allKeys = append(allKeys, keysToAdd...)
+
+		if len(keys) < perPage {
+			break
+		}
+
 		page++
 	}
 

--- a/server/oauth_migration.go
+++ b/server/oauth_migration.go
@@ -25,23 +25,20 @@ func (p *Plugin) checkAndPerformOAuthTokenMigration() error {
 	}
 
 	mutex.Lock()
+	defer mutex.Unlock()
 
 	var status string
 	err = p.client.KV.Get(oauthMigrationStoreKey, &status)
 	if err != nil {
-		mutex.Unlock()
 		return err
 	}
 
 	// Migration is in progress or already completed
 	if status != "" {
-		mutex.Unlock()
 		return nil
 	}
 
 	_, _ = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusInProgress)
-
-	mutex.Unlock()
 
 	err = p.notifyAllConnectedUsersToReconnect()
 	if err != nil {

--- a/server/oauth_migration.go
+++ b/server/oauth_migration.go
@@ -91,8 +91,7 @@ func (p *Plugin) notifyAllConnectedUsersToReconnect() error {
 
 	numErrors := 0
 	for _, key := range allKeys {
-		index := strings.Index(key, GitlabTokenKey)
-		userID := key[:index]
+		userID := strings.TrimSuffix(key, GitlabTokenKey)
 
 		var logError = func(msg string, err error) {
 			numErrors++

--- a/server/oauth_migration.go
+++ b/server/oauth_migration.go
@@ -79,10 +79,6 @@ func (p *Plugin) notifyAllConnectedUsersToReconnect() error {
 			if strings.HasSuffix(key, GitlabTokenKey) {
 				keysToAdd = append(keysToAdd, key)
 			}
-
-			if strings.HasSuffix(key, GitlabUsernameKey) || strings.HasSuffix(key, GitlabIDUsernameKey) {
-				_ = p.client.KV.Delete(key)
-			}
 		}
 
 		allKeys = append(allKeys, keysToAdd...)

--- a/server/oauth_migration.go
+++ b/server/oauth_migration.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-api/cluster"
+	"github.com/pkg/errors"
+)
+
+const (
+	oauthMigrationStoreKey = "oauth_migration"
+	oauthMigrationMutexKey = "oauth_migration_mutex"
+
+	oauthMigrationStatusInProgress = "IN_PROGRESS"
+	oauthMigrationStatusComplete   = "COMPLETE"
+	oauthMigrationStatusError      = "ERROR"
+)
+
+func (p *Plugin) checkAndPerformOAuthTokenMigration() error {
+	mutexAPI := cluster.MutexPluginAPI(p.API)
+	mutex, err := cluster.NewMutex(mutexAPI, oauthMigrationMutexKey)
+	if err != nil {
+		return err
+	}
+
+	mutex.Lock()
+
+	var status string
+	err = p.client.KV.Get(oauthMigrationStoreKey, &status)
+	if err != nil {
+		mutex.Unlock()
+		return err
+	}
+
+	// Migration is in progress or already completed
+	if status != "" {
+		mutex.Unlock()
+		return nil
+	}
+
+	_, _ = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusInProgress)
+
+	mutex.Unlock()
+
+	err = p.notifyAllConnectedUsersToReconnect()
+	if err != nil {
+		_, _ = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusError)
+		return err
+	}
+
+	_, _ = p.client.KV.Set(oauthMigrationStoreKey, oauthMigrationStatusComplete)
+
+	return nil
+}
+
+func (p *Plugin) notifyAllConnectedUsersToReconnect() error {
+	allKeys := []string{}
+	page := 0
+	for {
+		keys, err := p.client.KV.ListKeys(page, 100)
+		if err != nil {
+			return errors.Wrap(err, "error listing keys for connected users")
+		}
+
+		if len(keys) == 0 {
+			break
+		}
+
+		keysToAdd := []string{}
+		for _, key := range keys {
+			if strings.HasSuffix(key, GitlabTokenKey) {
+				keysToAdd = append(keysToAdd, key)
+			}
+
+			if strings.HasSuffix(key, GitlabUsernameKey) || strings.HasSuffix(key, GitlabIDUsernameKey) {
+				_ = p.client.KV.Delete(key)
+			}
+		}
+
+		allKeys = append(allKeys, keysToAdd...)
+		page++
+	}
+
+	updateMessage := "An update for this integration requires you to reconnect your account."
+	connectMessage := fmt.Sprintf(gitlabConnectMessage, *p.client.Configuration.GetConfig().ServiceSettings.SiteURL, manifest.Id)
+	fullMessage := fmt.Sprintf("%s %s", updateMessage, connectMessage)
+
+	numErrors := 0
+	for _, key := range allKeys {
+		index := strings.Index(key, GitlabTokenKey)
+		userID := key[0:index]
+
+		var logError = func(msg string, err error) {
+			numErrors++
+			if numErrors < 10 {
+				p.client.Log.Warn(msg, "user_id", userID, "err", err.Error())
+			}
+		}
+
+		_, err := p.poster.DM(userID, fullMessage)
+		if err != nil {
+			logError("error notifying user to reconnect", err)
+		}
+
+		err = p.client.KV.Delete(key)
+		if err != nil {
+			logError("error deleting key for connected user", err)
+		}
+	}
+
+	return nil
+}

--- a/server/oauth_migration_test.go
+++ b/server/oauth_migration_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-api/experimental/bot/poster"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
+)
+
+func TestNotifyAllConnectedUsersToReconnect(t *testing.T) {
+	p := new(Plugin)
+
+	testAPI := &plugintest.API{}
+
+	p.client = pluginapi.NewClient(testAPI, nil)
+	p.poster = poster.NewPoster(&p.client.Post, "botid")
+
+	userID := "someuser"
+	botID := "botid"
+	dmChannelID := "dm_channel_id"
+
+	tokenKey := userID + "_gitlabtoken"
+	usernameKey := "myusername_gitlabusername"
+	gitlabIDKey := "myid_gitlabidusername"
+
+	keys := []string{
+		"invalid",
+		tokenKey,
+	}
+
+	siteURL := "https://myserver.com"
+	testAPI.On("GetConfig").Return(
+		&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}},
+		nil,
+	)
+
+	testAPI.On("KVList", 0, 100).Return(keys, nil)
+	testAPI.On("KVList", 1, 100).Return([]string{}, nil)
+
+	testAPI.On("GetDirectChannel", botID, userID).Return(&model.Channel{Id: dmChannelID}, nil)
+
+	expected := "An update for this integration requires you to reconnect your account. [Click here to link your GitLab account.](https://myserver.com/plugins/com.github.manland.mattermost-plugin-gitlab/oauth/connect)"
+	testAPI.On("CreatePost", &model.Post{
+		ChannelId: dmChannelID,
+		UserId:    botID,
+		Message:   expected,
+	}).Return(&model.Post{}, nil)
+
+	testAPI.On("KVSetWithOptions", tokenKey, []byte(nil), mock.Anything).Return(true, nil)
+	testAPI.On("KVSetWithOptions", usernameKey, []byte(nil), mock.Anything).Return(true, nil)
+	testAPI.On("KVSetWithOptions", gitlabIDKey, []byte(nil), mock.Anything).Return(true, nil)
+
+	p.SetAPI(testAPI)
+
+	err := p.notifyAllConnectedUsersToReconnect()
+	require.NoError(t, err)
+}

--- a/server/oauth_migration_test.go
+++ b/server/oauth_migration_test.go
@@ -38,7 +38,6 @@ func TestNotifyAllConnectedUsersToReconnect(t *testing.T) {
 	)
 
 	testAPI.On("KVList", 0, 100).Return(keys, nil)
-	testAPI.On("KVList", 1, 100).Return([]string{}, nil)
 
 	testAPI.On("GetDirectChannel", botID, userID).Return(&model.Channel{Id: dmChannelID}, nil)
 

--- a/server/oauth_migration_test.go
+++ b/server/oauth_migration_test.go
@@ -25,8 +25,6 @@ func TestNotifyAllConnectedUsersToReconnect(t *testing.T) {
 	dmChannelID := "dm_channel_id"
 
 	tokenKey := userID + "_gitlabtoken"
-	usernameKey := "myusername_gitlabusername"
-	gitlabIDKey := "myid_gitlabidusername"
 
 	keys := []string{
 		"invalid",
@@ -52,8 +50,6 @@ func TestNotifyAllConnectedUsersToReconnect(t *testing.T) {
 	}).Return(&model.Post{}, nil)
 
 	testAPI.On("KVSetWithOptions", tokenKey, []byte(nil), mock.Anything).Return(true, nil)
-	testAPI.On("KVSetWithOptions", usernameKey, []byte(nil), mock.Anything).Return(true, nil)
-	testAPI.On("KVSetWithOptions", gitlabIDKey, []byte(nil), mock.Anything).Return(true, nil)
 
 	p.SetAPI(testAPI)
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -122,6 +122,11 @@ func (p *Plugin) OnActivate() error {
 	p.poster = poster.NewPoster(&p.client.Post, p.BotUserID)
 	p.flowManager = p.NewFlowManager()
 
+	err = p.checkAndPerformOAuthTokenMigration()
+	if err != nil {
+		p.API.LogWarn("error performing oauth token migration", "error", err.Error())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### Summary

This PR aims to fix the revoked token issue by doing the following on startup:

- acquire mutex to gain control, to run a data migration
- for all connected users:
  - remove stored token, and any other gitlab-related information, from the kv store
  - DM the user telling them to reconnect their account

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/261