### PR TITLE
Increase slash command timeout to 30 seconds

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -88,7 +88,7 @@ const (
 )
 
 const (
-	commandTimeout = 6 * time.Second
+	commandTimeout = 30 * time.Second
 )
 
 func (p *Plugin) getCommand(config *configuration) (*model.Command, error) {


### PR DESCRIPTION
#### Summary

The timeout for slash commands is currently 6 seconds, which is causing issues for the `/gitlab webhook add` command. This PR increases the timeout to 30 seconds, which is what is currently used for incoming http requests:

https://github.com/mattermost/mattermost-plugin-gitlab/blob/de004a91ffc37e39f73d85824c93577bf88e16fa/server/api.go#L31

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/374