### PR TITLE
[MM-52887] Fix panic if todo is not part of a project

### DIFF
--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -611,9 +611,10 @@ func (g *gitlab) GetUnreads(ctx context.Context, user *UserInfo, token *oauth2.T
 		}
 		opt.Page = resp.NextPage
 	}
+
 	notifications := make([]*internGitlab.Todo, 0, len(todos))
 	for _, todo := range todos {
-		if g.checkGroup(strings.TrimSuffix(todo.Project.PathWithNamespace, "/"+todo.Project.Path)) != nil {
+		if todo.Project != nil && g.checkGroup(strings.TrimSuffix(todo.Project.PathWithNamespace, "/"+todo.Project.Path)) != nil {
 			continue
 		}
 		notifications = append(notifications, todo)

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -614,6 +614,10 @@ func (g *gitlab) GetUnreads(ctx context.Context, user *UserInfo, token *oauth2.T
 
 	notifications := make([]*internGitlab.Todo, 0, len(todos))
 	for _, todo := range todos {
+		if todo == nil {
+			continue
+		}
+
 		if todo.Project != nil && g.checkGroup(strings.TrimSuffix(todo.Project.PathWithNamespace, "/"+todo.Project.Path)) != nil {
 			continue
 		}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -536,6 +536,10 @@ func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, stri
 		notificationContent := ""
 
 		for _, n := range unreads {
+			if n == nil {
+				continue
+			}
+
 			if n.Project != nil && p.isNamespaceAllowed(n.Project.NameWithNamespace) != nil {
 				continue
 			}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -536,7 +536,7 @@ func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, stri
 		notificationContent := ""
 
 		for _, n := range unreads {
-			if p.isNamespaceAllowed(n.Project.NameWithNamespace) != nil {
+			if n.Project != nil && p.isNamespaceAllowed(n.Project.NameWithNamespace) != nil {
 				continue
 			}
 			notificationCount++


### PR DESCRIPTION
#### Summary
According to https://docs.gitlab.com/ee/user/todos.html there are todos that are not part of a project. For example, member access requests for groups are only tied to the group, not a project. This PR fixes the NPE by checking if a project is there first.

There are no tests that cover the outgoing API requests, and hence the changes in this PR are not covered by tests.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52887
Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/372
