### PR TITLE
README editorial pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Originally developed by [Romain Maneschi](https://github.com/manland). This proj
 
 **Co-Maintainer:** [@hanzei](https://github.com/hanzei)
 
-## Feature Summary of GitLab to Mattermost Notifications
+## Feature summary of GitLab to Mattermost notifications
 
-### Channel Subscriptions
+### Channel subscriptions
 
 Notify your team of the latest updates by sending notifications from your GitLab group or repository to Mattermost channels. When team members log in the first time to Mattermost each day, they can get a post letting them know what issues and merge requests need their attention. They can also get a refresh of new events by selecting **Refresh** from every webhook configured in GitLab.
 
@@ -34,15 +34,15 @@ You can specify which events trigger a notification. They can see:
 - label:"<labelname>" - must include "merges" or "issues" in feature list when using a label
 - Defaults to "merges,issues,tag"
 
-### Personal Notifications: GitLab Bot
+### Personal notifications: GitLab bot
 
 Each user in Mattermost is connected with their own personal GitLab account. Users can get a direct message in Mattermost when someone mentions them, requests their review, comments on, or modifies one of their merge requests/issues, or assigns them on GitLab.
 
-### Sidebar Buttons
+### Sidebar buttons
 
 Team members can stay up-to-date with how many reviews, unread messages, assignments, and open merge requests they have by using buttons in the Mattermost sidebar.
 
-## Admin Guide
+## Admin guide
   
 Get started by installing the GitLab plugin from the Marketplace.
 
@@ -51,21 +51,23 @@ Get started by installing the GitLab plugin from the Marketplace.
 * The GitLab plugin is included in the Plugin Marketplace in Mattermost v5.16 and above.
 * For Mattermost v5.13 and earlier, a manual install is necessary.
 
-### Marketplace Installation
+## Installation
+  
+### Marketplace installation
 
 1. Go to **Main Menu > Plugin Marketplace** in Mattermost.
 2. Search for "gitlab" or manually find the plugin from the list and select **Install**.
 3. After the plugin has downloaded and been installed, select the **Configure** button.
 
-### Manual Installation
+### Manual installation
 
 If your server doesn't have access to the internet, you can download the latest [plugin binary release](https://github.com/mattermost/mattermost-plugin-gitlab/releases) and upload it to your server via **System Console > Plugins > Plugin Management**. The releases on this page are the same used by the Marketplace. 
 
 See the [GitLab plugin release page](https://github.com/mattermost/mattermost-plugin-gitlab/releases) for compatibility considerations.
 
-### Configuration
+## Configuration
 
-#### Step 1: Register an OAuth Application in GitLab
+### Step 1: Register an OAuth application in GitLab
 
 1. Go to https://gitlab.com/-/profile/applications or https://gitlab.yourdomain.com/-/profile/applications to register an OAuth app.
 1. Set the following values:
@@ -75,7 +77,7 @@ See the [GitLab plugin release page](https://github.com/mattermost/mattermost-pl
 1. Save the application. Copy the **Application ID** and **Secret** fields in the resulting screen.
 1. In Mattermost, go to **Plugins Marketplace > GitLab > Configure**, and enter the **GitLab URL**, **GitLab OAuth Client ID**, and **GitLab OAuth Client Secret**.
 
-#### Step 2: Configure the Plugin in Mattermost
+### Step 2: Configure the plugin in Mattermost
 
 1. Go to **System Console > Plugins > GitLab** and do the following:
     - Generate a new value for **Webhook Secret**.
@@ -85,11 +87,11 @@ See the [GitLab plugin release page](https://github.com/mattermost/mattermost-pl
 1. Select **Save**.
 1. Go to **Plugins Marketplace > GitLab > Configure > Enable Plugin** and select **Enable** to enable the GitLab plugin.
 
-#### Step 3: Connect Your GitLab Accounts
+### Step 3: Connect your GitLab accounts
 
 Run the `/gitlab connect` slash command to connect your Mattermost account with GitLab.
 
-#### Step 4: Subscribe to Projects and Groups
+### Step 4: Subscribe to projects and groups
 
 For each project you want to receive notifications for or subscribe to, you must create a webhook. Run the subscribe slash command to watch events sent from GitLab.
 
@@ -116,15 +118,15 @@ For versions prior to 1.2:
 |        0.2.0            |     5.8+   |  11.2+ |
 |        0.1.0            |     5.8+   |  11.2+ |
 
-### Update the Plugin
+### Update the plugin
 
 When a new version of the plugin is released to the **Plugin Marketplace**, the system will display a prompt asking you to update your current version of the GitLab plugin to the newest one. There may be a warning shown if there is a major version change that **may** affect the installation. Generally, updates are seamless and don't interrupt the user experience in Mattermost.
   
-## Mattermost Commands User Guide
+## Mattermost commands user guide
 
 Interact with the GitLab plugin using the `/gitlab` slash command.
 
-### Subscribe To/Unsubscribe From a Repository
+### Subscribe to/unsubscribe from a repository
 
 Use `/gitlab subscriptions add owner[/repo] [features]` to subscribe a Mattermost channel to receive posts for new merge requests and/or issues, or other features (as listed above), from a GitLab repository. Ensure that the webhook is configured, otherwise this will not work properly.
 
@@ -132,24 +134,24 @@ Use `/gitlab subscriptions delete owner/repo` to unsubscribe from it.
 
 `/gitlab subscriptions list` lists what you have subscribed to.
 
-### Connect To/Disconnect From GitLab
+### Connect to/disconnect from GitLab
 
 Connect your Mattermost account to your GitLab account using `/gitlab connect` and disconnect it using`/gitlab disconnect`. 
 
 `/gitlab me` displays the connected GitLab account.
 
-### Get "To Do" Items
+### Get "To Do" items
 
 Use `/gitlab todo` to get a list of unread messages and merge requests awaiting your review.
 
-### Update Settings
+### Update settings
 
 Use `/gitlab settings [setting] [value]` to update your settings for the plugin.  There are two settings:
 
 - To turn **personal notifications** `on` or `off.
 - To turn **reminders** `on` or `off` for when you connect for the first time each day.  
 
-### And More...
+### And more...
 
 Run `/gitlab help` to see what else the slash command can do.
 
@@ -159,13 +161,13 @@ Run `/gitlab help` to see what else the slash command can do.
   
 This plugin contains both a server and web app portion. Read our documentation about the [Developer Workflow](https://developers.mattermost.com/extend/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/extend/plugins/developer-setup/) for more information about developing and extending plugins.
   
-## Help Wanted!
+## Help wanted!
 
 If you're interested in joining our community of developers who contribute to Mattermost - check out the current set of issues [that are being requested](https://github.com/mattermost/mattermost-plugin-gitlab/issues?q=is%3Aissue+is%3Aopen+label%3AEnhancement).
 
 You can also find issues labeled ["Help Wanted"](https://github.com/mattermost/mattermost-plugin-gitlab/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22) in the GitLab plugin repository that we have laid out the primary requirements for and could use some coding help from the community.
 
-## Help and Support
+## Help and support
 
 For Mattermost customers - please open a [support case](https://mattermost.zendesk.com/hc/en-us/requests/new) to ensure your issue is tracked properly.
 
@@ -173,8 +175,7 @@ For Questions, suggestions, and help - please find us on our forum at [https://f
 
 Alternatively, join our public Mattermost server and join the [Integrations and Apps channel](https://community-daily.mattermost.com/core/channels/integrations).
 
-
-## Feedback and Feature Requests
+## Feedback and feature requests
 
 Feel free to create a GitHub issue or [join the GitLab Plugin channel on our community Mattermost instance](https://community.mattermost.com/core/channels/plugin-gitlab) to discuss.
 


### PR DESCRIPTION
Final editorial pass of the repository's README content. Aligning updates across all GitBook migrations.
