### PR TITLE
Remove duplicate oauth step

### DIFF
--- a/server/flow.go
+++ b/server/flow.go
@@ -82,7 +82,6 @@ func (p *Plugin) NewFlowManager() *FlowManager {
 	fm.oauthFlow = fm.newFlow("oauth").WithSteps(
 		fm.stepInstanceURL(),
 		fm.stepOAuthInfo(),
-		fm.stepOAuthInfo(),
 		fm.stepOAuthInput(),
 		fm.stepOAuthConnect().Terminal(),
 


### PR DESCRIPTION
#### Summary
This PR removes a duplicate step from the oauth setup flow. Please note that this change doesn't impact users -  the flow library already ensured that duplicate steps don't get shown.

#### Ticket Link
None