### PR TITLE
Revert #308 [GH-261] Handle revoked token

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	gitlabLib "github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -355,14 +354,6 @@ func (p *Plugin) completeConnectUserToGitlab(c *Context, w http.ResponseWriter, 
 		return
 	}
 
-	if err = p.storeGitlabUserToken(userInfo.UserID, tok); err != nil {
-		c.Log.WithError(err).Warnf("Can't store user token")
-
-		rErr = errors.Wrap(err, "Unable to connect user to GitLab")
-		http.Error(w, rErr.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	if err = p.storeGitlabToUserIDMapping(userInfo.GitlabUsername, userID); err != nil {
 		c.Log.WithError(err).Warnf("Can't store GitLab to user id mapping")
 	}
@@ -500,7 +491,7 @@ func (p *Plugin) getConnected(c *Context, w http.ResponseWriter, r *http.Request
 	}
 
 	info, _ := p.getGitlabUserInfoByMattermostID(c.UserID)
-	if info != nil {
+	if info != nil && info.Token != nil {
 		resp.Connected = true
 		resp.GitlabUsername = info.GitlabUsername
 		resp.GitlabClientID = config.GitlabOAuthClientID
@@ -531,16 +522,7 @@ func (p *Plugin) getConnected(c *Context, w http.ResponseWriter, r *http.Request
 }
 
 func (p *Plugin) getUnreads(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	var result []*gitlabLib.Todo
-	err := p.useGitlabClient(c.GitlabInfo, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetUnreads(c.Ctx, info, token)
-		if err != nil {
-			return err
-		}
-		result = resp
-		return nil
-	})
-
+	result, err := p.GitlabClient.GetUnreads(c.Ctx, c.GitlabInfo)
 	if err != nil {
 		c.Log.WithError(err).Warnf("Unable to list unreads in GitLab API")
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Unable to list unreads in GitLab API.", StatusCode: http.StatusInternalServerError})
@@ -551,16 +533,7 @@ func (p *Plugin) getUnreads(c *UserContext, w http.ResponseWriter, r *http.Reque
 }
 
 func (p *Plugin) getReviews(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	var result []*gitlab.MergeRequest
-	err := p.useGitlabClient(c.GitlabInfo, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetReviews(c.Ctx, info, token)
-		if err != nil {
-			return err
-		}
-		result = resp
-		return nil
-	})
-
+	result, err := p.GitlabClient.GetReviews(c.Ctx, c.GitlabInfo)
 	if err != nil {
 		c.Log.WithError(err).Warnf("Unable to list merge-request where assignee in GitLab API")
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Unable to list merge-request in GitLab API.", StatusCode: http.StatusInternalServerError})
@@ -571,16 +544,7 @@ func (p *Plugin) getReviews(c *UserContext, w http.ResponseWriter, r *http.Reque
 }
 
 func (p *Plugin) getYourPrs(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	var result []*gitlab.MergeRequest
-	err := p.useGitlabClient(c.GitlabInfo, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetYourPrs(c.Ctx, info, token)
-		if err != nil {
-			return err
-		}
-		result = resp
-		return nil
-	})
-
+	result, err := p.GitlabClient.GetYourPrs(c.Ctx, c.GitlabInfo)
 	if err != nil {
 		c.Log.WithError(err).Warnf("Can't list merge-request where author in GitLab API")
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Unable to list merge-request in GitLab API.", StatusCode: http.StatusInternalServerError})
@@ -597,15 +561,7 @@ func (p *Plugin) getPrDetails(c *UserContext, w http.ResponseWriter, r *http.Req
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: fmt.Sprintf("Error decoding PRDetails JSON body. Error: %s", err.Error()), StatusCode: http.StatusBadRequest})
 		return
 	}
-	var result []*gitlab.PRDetails
-	err := p.useGitlabClient(c.GitlabInfo, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetYourPrDetails(c.Ctx, c.Log, info, token, prList)
-		if err != nil {
-			return err
-		}
-		result = resp
-		return nil
-	})
+	result, err := p.GitlabClient.GetYourPrDetails(c.Ctx, c.Log, c.GitlabInfo, prList)
 	if err != nil {
 		c.Log.WithError(err).Warnf("Can't list merge-request details in GitLab API")
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: fmt.Sprintf("Can't list merge-request details in GitLab API. Error: %s", err.Error()), StatusCode: http.StatusInternalServerError})
@@ -616,16 +572,7 @@ func (p *Plugin) getPrDetails(c *UserContext, w http.ResponseWriter, r *http.Req
 }
 
 func (p *Plugin) getYourAssignments(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	var result []*gitlab.Issue
-	err := p.useGitlabClient(c.GitlabInfo, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetYourAssignments(c.Ctx, info, token)
-		if err != nil {
-			return err
-		}
-		result = resp
-		return nil
-	})
-
+	result, err := p.GitlabClient.GetYourAssignments(c.Ctx, c.GitlabInfo)
 	if err != nil {
 		c.Log.WithError(err).Warnf("Unable to list issue where assignee in GitLab API")
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Unable to list issue in GitLab API.", StatusCode: http.StatusInternalServerError})

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	"github.com/mattermost/mattermost-plugin-gitlab/server/gitlab"
 )
@@ -30,11 +32,20 @@ func TestGetChannelSubscriptions(t *testing.T) {
 		plugin := Plugin{configuration: &config}
 		plugin.initializeAPI()
 
+		token := oauth2.Token{
+			AccessToken: "access_token",
+			Expiry:      time.Now().Add(1 * time.Hour),
+		}
 		info := gitlab.UserInfo{
 			UserID:         "user_id",
+			Token:          &token,
 			GitlabUsername: "gitlab_username",
 			GitlabUserID:   0,
 		}
+		encryptedToken, err := encrypt([]byte(config.EncryptionKey), info.Token.AccessToken)
+		require.NoError(t, err)
+
+		info.Token.AccessToken = encryptedToken
 
 		jsonInfo, err := json.Marshal(info)
 		require.NoError(t, err)
@@ -43,7 +54,7 @@ func TestGetChannelSubscriptions(t *testing.T) {
 		plugin.SetAPI(mock)
 		plugin.client = pluginapi.NewClient(plugin.API, plugin.Driver)
 
-		mock.On("KVGet", "user_id_userinfo").Return(jsonInfo, nil).Once()
+		mock.On("KVGet", "user_id_gitlabtoken").Return(jsonInfo, nil).Once()
 
 		return &plugin, mock
 	}

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/pkg/errors"
 	internGitlab "github.com/xanzy/go-gitlab"
-	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -41,8 +40,8 @@ type Issue struct {
 }
 
 // NewGroupHook creates a webhook associated with a GitLab group
-func (g *gitlab) NewGroupHook(ctx context.Context, user *UserInfo, token *oauth2.Token, groupName string, webhookOptions *AddWebhookOptions) (*WebhookInfo, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) NewGroupHook(ctx context.Context, user *UserInfo, groupName string, webhookOptions *AddWebhookOptions) (*WebhookInfo, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +85,8 @@ func (g *gitlab) NewGroupHook(ctx context.Context, user *UserInfo, token *oauth2
 }
 
 // NewProjectHook creates a webhook associated with a GitLab project
-func (g *gitlab) NewProjectHook(ctx context.Context, user *UserInfo, token *oauth2.Token, projectID interface{}, webhookOptions *AddWebhookOptions) (*WebhookInfo, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) NewProjectHook(ctx context.Context, user *UserInfo, projectID interface{}, webhookOptions *AddWebhookOptions) (*WebhookInfo, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -122,8 +121,8 @@ func (g *gitlab) NewProjectHook(ctx context.Context, user *UserInfo, token *oaut
 }
 
 // GetGroupHooks gathers all the group level hooks for a GitLab group.
-func (g *gitlab) GetGroupHooks(ctx context.Context, user *UserInfo, token *oauth2.Token, owner string) ([]*WebhookInfo, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetGroupHooks(ctx context.Context, user *UserInfo, owner string) ([]*WebhookInfo, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -229,8 +228,8 @@ func getGroupHookInfo(hook *internGitlab.GroupHook) *WebhookInfo {
 }
 
 // GetProjectHooks gathers all the project level hooks from a single GitLab project.
-func (g *gitlab) GetProjectHooks(ctx context.Context, user *UserInfo, token *oauth2.Token, owner string, repo string) ([]*WebhookInfo, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetProjectHooks(ctx context.Context, user *UserInfo, owner string, repo string) ([]*WebhookInfo, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -262,8 +261,8 @@ func (g *gitlab) GetProjectHooks(ctx context.Context, user *UserInfo, token *oau
 	return webhooks, nil
 }
 
-func (g *gitlab) GetProject(ctx context.Context, user *UserInfo, token *oauth2.Token, owner, repo string) (*internGitlab.Project, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetProject(ctx context.Context, user *UserInfo, owner, repo string) (*internGitlab.Project, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -282,8 +281,8 @@ func (g *gitlab) GetProject(ctx context.Context, user *UserInfo, token *oauth2.T
 	return project, nil
 }
 
-func (g *gitlab) GetReviews(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*MergeRequest, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetReviews(ctx context.Context, user *UserInfo) ([]*MergeRequest, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -353,8 +352,8 @@ func (g *gitlab) GetReviews(ctx context.Context, user *UserInfo, token *oauth2.T
 	return mergeRequests, err
 }
 
-func (g *gitlab) GetYourPrs(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*MergeRequest, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetYourPrs(ctx context.Context, user *UserInfo) ([]*MergeRequest, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -450,8 +449,8 @@ func (g *gitlab) GetLabelDetails(client *internGitlab.Client, pid int, labels in
 	return labelsWithDetails, nil
 }
 
-func (g *gitlab) GetYourPrDetails(ctx context.Context, log logger.Logger, user *UserInfo, token *oauth2.Token, prList []*PRDetails) ([]*PRDetails, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetYourPrDetails(ctx context.Context, log logger.Logger, user *UserInfo, prList []*PRDetails) ([]*PRDetails, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -518,8 +517,8 @@ func (g *gitlab) fetchYourPrDetails(c context.Context, log logger.Logger, client
 	return nil
 }
 
-func (g *gitlab) GetYourAssignments(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*Issue, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetYourAssignments(ctx context.Context, user *UserInfo) ([]*Issue, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -588,8 +587,8 @@ func (g *gitlab) GetYourAssignments(ctx context.Context, user *UserInfo, token *
 	return result, nil
 }
 
-func (g *gitlab) GetUnreads(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*internGitlab.Todo, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetUnreads(ctx context.Context, user *UserInfo) ([]*internGitlab.Todo, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}
@@ -630,12 +629,11 @@ func (g *gitlab) GetUnreads(ctx context.Context, user *UserInfo, token *oauth2.T
 func (g *gitlab) ResolveNamespaceAndProject(
 	ctx context.Context,
 	userInfo *UserInfo,
-	token *oauth2.Token,
 	fullPath string,
 	allowPrivate bool,
 ) (owner string, repo string, err error) {
 	// Initialize client
-	client, err := g.GitlabConnect(*token)
+	client, err := g.GitlabConnect(*userInfo.Token)
 	if err != nil {
 		return "", "", err
 	}
@@ -720,8 +718,8 @@ func (g *gitlab) ResolveNamespaceAndProject(
 }
 
 // TriggerProjectPipeline runs a pipeline in a specific project
-func (g *gitlab) TriggerProjectPipeline(userInfo *UserInfo, token *oauth2.Token, projectID string, ref string) (*PipelineInfo, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) TriggerProjectPipeline(userInfo *UserInfo, projectID string, ref string) (*PipelineInfo, error) {
+	client, err := g.GitlabConnect(*userInfo.Token)
 	if err != nil {
 		return &PipelineInfo{}, err
 	}

--- a/server/gitlab/gitlab.go
+++ b/server/gitlab/gitlab.go
@@ -25,18 +25,18 @@ var (
 type Gitlab interface {
 	GitlabConnect(token oauth2.Token) (*internGitlab.Client, error)
 	GetCurrentUser(ctx context.Context, userID string, token oauth2.Token) (*UserInfo, error)
-	GetUserDetails(ctx context.Context, user *UserInfo, token *oauth2.Token) (*internGitlab.User, error)
-	GetProject(ctx context.Context, user *UserInfo, token *oauth2.Token, owner, repo string) (*internGitlab.Project, error)
-	GetYourPrDetails(ctx context.Context, log logger.Logger, user *UserInfo, token *oauth2.Token, prList []*PRDetails) ([]*PRDetails, error)
-	GetReviews(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*MergeRequest, error)
-	GetYourPrs(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*MergeRequest, error)
-	GetYourAssignments(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*Issue, error)
-	GetUnreads(ctx context.Context, user *UserInfo, token *oauth2.Token) ([]*internGitlab.Todo, error)
-	GetProjectHooks(ctx context.Context, user *UserInfo, token *oauth2.Token, owner string, repo string) ([]*WebhookInfo, error)
-	GetGroupHooks(ctx context.Context, user *UserInfo, token *oauth2.Token, owner string) ([]*WebhookInfo, error)
-	NewProjectHook(ctx context.Context, user *UserInfo, token *oauth2.Token, projectID interface{}, projectHookOptions *AddWebhookOptions) (*WebhookInfo, error)
-	NewGroupHook(ctx context.Context, user *UserInfo, token *oauth2.Token, groupName string, groupHookOptions *AddWebhookOptions) (*WebhookInfo, error)
-	TriggerProjectPipeline(userInfo *UserInfo, token *oauth2.Token, projectID string, ref string) (*PipelineInfo, error)
+	GetUserDetails(ctx context.Context, user *UserInfo) (*internGitlab.User, error)
+	GetProject(ctx context.Context, user *UserInfo, owner, repo string) (*internGitlab.Project, error)
+	GetYourPrDetails(ctx context.Context, log logger.Logger, user *UserInfo, prList []*PRDetails) ([]*PRDetails, error)
+	GetReviews(ctx context.Context, user *UserInfo) ([]*MergeRequest, error)
+	GetYourPrs(ctx context.Context, user *UserInfo) ([]*MergeRequest, error)
+	GetYourAssignments(ctx context.Context, user *UserInfo) ([]*Issue, error)
+	GetUnreads(ctx context.Context, user *UserInfo) ([]*internGitlab.Todo, error)
+	GetProjectHooks(ctx context.Context, user *UserInfo, owner string, repo string) ([]*WebhookInfo, error)
+	GetGroupHooks(ctx context.Context, user *UserInfo, owner string) ([]*WebhookInfo, error)
+	NewProjectHook(ctx context.Context, user *UserInfo, projectID interface{}, projectHookOptions *AddWebhookOptions) (*WebhookInfo, error)
+	NewGroupHook(ctx context.Context, user *UserInfo, groupName string, groupHookOptions *AddWebhookOptions) (*WebhookInfo, error)
+	TriggerProjectPipeline(userInfo *UserInfo, projectID string, ref string) (*PipelineInfo, error)
 	// ResolveNamespaceAndProject accepts full path to User, Group or namespaced Project and returns corresponding
 	// namespace and project name.
 	//
@@ -45,7 +45,6 @@ type Gitlab interface {
 	ResolveNamespaceAndProject(
 		ctx context.Context,
 		userInfo *UserInfo,
-		token *oauth2.Token,
 		fullPath string,
 		allowPrivate bool,
 	) (namespace string, project string, err error)

--- a/server/gitlab/mocks/mock_gitlab.go
+++ b/server/gitlab/mocks/mock_gitlab.go
@@ -54,138 +54,138 @@ func (mr *MockGitlabMockRecorder) GetCurrentUser(arg0, arg1, arg2 interface{}) *
 }
 
 // GetGroupHooks mocks base method.
-func (m *MockGitlab) GetGroupHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 string) ([]*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) GetGroupHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 string) ([]*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGroupHooks", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetGroupHooks", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetGroupHooks indicates an expected call of GetGroupHooks.
-func (mr *MockGitlabMockRecorder) GetGroupHooks(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetGroupHooks(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupHooks", reflect.TypeOf((*MockGitlab)(nil).GetGroupHooks), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupHooks", reflect.TypeOf((*MockGitlab)(nil).GetGroupHooks), arg0, arg1, arg2)
 }
 
 // GetProject mocks base method.
-func (m *MockGitlab) GetProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3, arg4 string) (*gitlab0.Project, error) {
+func (m *MockGitlab) GetProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2, arg3 string) (*gitlab0.Project, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProject", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GetProject", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*gitlab0.Project)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProject indicates an expected call of GetProject.
-func (mr *MockGitlabMockRecorder) GetProject(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetProject(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockGitlab)(nil).GetProject), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockGitlab)(nil).GetProject), arg0, arg1, arg2, arg3)
 }
 
 // GetProjectHooks mocks base method.
-func (m *MockGitlab) GetProjectHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3, arg4 string) ([]*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) GetProjectHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2, arg3 string) ([]*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectHooks", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GetProjectHooks", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjectHooks indicates an expected call of GetProjectHooks.
-func (mr *MockGitlabMockRecorder) GetProjectHooks(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetProjectHooks(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectHooks", reflect.TypeOf((*MockGitlab)(nil).GetProjectHooks), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectHooks", reflect.TypeOf((*MockGitlab)(nil).GetProjectHooks), arg0, arg1, arg2, arg3)
 }
 
 // GetReviews mocks base method.
-func (m *MockGitlab) GetReviews(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab.MergeRequest, error) {
+func (m *MockGitlab) GetReviews(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab.MergeRequest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReviews", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetReviews", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab.MergeRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetReviews indicates an expected call of GetReviews.
-func (mr *MockGitlabMockRecorder) GetReviews(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetReviews(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReviews", reflect.TypeOf((*MockGitlab)(nil).GetReviews), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReviews", reflect.TypeOf((*MockGitlab)(nil).GetReviews), arg0, arg1)
 }
 
 // GetUnreads mocks base method.
-func (m *MockGitlab) GetUnreads(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab0.Todo, error) {
+func (m *MockGitlab) GetUnreads(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab0.Todo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnreads", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetUnreads", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab0.Todo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUnreads indicates an expected call of GetUnreads.
-func (mr *MockGitlabMockRecorder) GetUnreads(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetUnreads(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnreads", reflect.TypeOf((*MockGitlab)(nil).GetUnreads), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnreads", reflect.TypeOf((*MockGitlab)(nil).GetUnreads), arg0, arg1)
 }
 
 // GetUserDetails mocks base method.
-func (m *MockGitlab) GetUserDetails(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) (*gitlab0.User, error) {
+func (m *MockGitlab) GetUserDetails(arg0 context.Context, arg1 *gitlab.UserInfo) (*gitlab0.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserDetails", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetUserDetails", arg0, arg1)
 	ret0, _ := ret[0].(*gitlab0.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserDetails indicates an expected call of GetUserDetails.
-func (mr *MockGitlabMockRecorder) GetUserDetails(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetUserDetails(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserDetails", reflect.TypeOf((*MockGitlab)(nil).GetUserDetails), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserDetails", reflect.TypeOf((*MockGitlab)(nil).GetUserDetails), arg0, arg1)
 }
 
 // GetYourAssignments mocks base method.
-func (m *MockGitlab) GetYourAssignments(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab.Issue, error) {
+func (m *MockGitlab) GetYourAssignments(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab.Issue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetYourAssignments", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetYourAssignments", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab.Issue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetYourAssignments indicates an expected call of GetYourAssignments.
-func (mr *MockGitlabMockRecorder) GetYourAssignments(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetYourAssignments(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourAssignments", reflect.TypeOf((*MockGitlab)(nil).GetYourAssignments), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourAssignments", reflect.TypeOf((*MockGitlab)(nil).GetYourAssignments), arg0, arg1)
 }
 
 // GetYourPrDetails mocks base method.
-func (m *MockGitlab) GetYourPrDetails(arg0 context.Context, arg1 logger.Logger, arg2 *gitlab.UserInfo, arg3 *oauth2.Token, arg4 []*gitlab.PRDetails) ([]*gitlab.PRDetails, error) {
+func (m *MockGitlab) GetYourPrDetails(arg0 context.Context, arg1 logger.Logger, arg2 *gitlab.UserInfo, arg3 []*gitlab.PRDetails) ([]*gitlab.PRDetails, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetYourPrDetails", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GetYourPrDetails", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*gitlab.PRDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetYourPrDetails indicates an expected call of GetYourPrDetails.
-func (mr *MockGitlabMockRecorder) GetYourPrDetails(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetYourPrDetails(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrDetails", reflect.TypeOf((*MockGitlab)(nil).GetYourPrDetails), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrDetails", reflect.TypeOf((*MockGitlab)(nil).GetYourPrDetails), arg0, arg1, arg2, arg3)
 }
 
 // GetYourPrs mocks base method.
-func (m *MockGitlab) GetYourPrs(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab.MergeRequest, error) {
+func (m *MockGitlab) GetYourPrs(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab.MergeRequest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetYourPrs", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetYourPrs", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab.MergeRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetYourPrs indicates an expected call of GetYourPrs.
-func (mr *MockGitlabMockRecorder) GetYourPrs(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetYourPrs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrs", reflect.TypeOf((*MockGitlab)(nil).GetYourPrs), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrs", reflect.TypeOf((*MockGitlab)(nil).GetYourPrs), arg0, arg1)
 }
 
 // GitlabConnect mocks base method.
@@ -204,39 +204,39 @@ func (mr *MockGitlabMockRecorder) GitlabConnect(arg0 interface{}) *gomock.Call {
 }
 
 // NewGroupHook mocks base method.
-func (m *MockGitlab) NewGroupHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 string, arg4 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) NewGroupHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 string, arg3 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewGroupHook", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "NewGroupHook", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewGroupHook indicates an expected call of NewGroupHook.
-func (mr *MockGitlabMockRecorder) NewGroupHook(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) NewGroupHook(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroupHook", reflect.TypeOf((*MockGitlab)(nil).NewGroupHook), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroupHook", reflect.TypeOf((*MockGitlab)(nil).NewGroupHook), arg0, arg1, arg2, arg3)
 }
 
 // NewProjectHook mocks base method.
-func (m *MockGitlab) NewProjectHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 interface{}, arg4 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) NewProjectHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 interface{}, arg3 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewProjectHook", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "NewProjectHook", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewProjectHook indicates an expected call of NewProjectHook.
-func (mr *MockGitlabMockRecorder) NewProjectHook(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) NewProjectHook(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProjectHook", reflect.TypeOf((*MockGitlab)(nil).NewProjectHook), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProjectHook", reflect.TypeOf((*MockGitlab)(nil).NewProjectHook), arg0, arg1, arg2, arg3)
 }
 
 // ResolveNamespaceAndProject mocks base method.
-func (m *MockGitlab) ResolveNamespaceAndProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 string, arg4 bool) (string, string, error) {
+func (m *MockGitlab) ResolveNamespaceAndProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 string, arg3 bool) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveNamespaceAndProject", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "ResolveNamespaceAndProject", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -244,22 +244,22 @@ func (m *MockGitlab) ResolveNamespaceAndProject(arg0 context.Context, arg1 *gitl
 }
 
 // ResolveNamespaceAndProject indicates an expected call of ResolveNamespaceAndProject.
-func (mr *MockGitlabMockRecorder) ResolveNamespaceAndProject(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) ResolveNamespaceAndProject(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNamespaceAndProject", reflect.TypeOf((*MockGitlab)(nil).ResolveNamespaceAndProject), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNamespaceAndProject", reflect.TypeOf((*MockGitlab)(nil).ResolveNamespaceAndProject), arg0, arg1, arg2, arg3)
 }
 
 // TriggerProjectPipeline mocks base method.
-func (m *MockGitlab) TriggerProjectPipeline(arg0 *gitlab.UserInfo, arg1 *oauth2.Token, arg2, arg3 string) (*gitlab.PipelineInfo, error) {
+func (m *MockGitlab) TriggerProjectPipeline(arg0 *gitlab.UserInfo, arg1, arg2 string) (*gitlab.PipelineInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TriggerProjectPipeline", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "TriggerProjectPipeline", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*gitlab.PipelineInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TriggerProjectPipeline indicates an expected call of TriggerProjectPipeline.
-func (mr *MockGitlabMockRecorder) TriggerProjectPipeline(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) TriggerProjectPipeline(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerProjectPipeline", reflect.TypeOf((*MockGitlab)(nil).TriggerProjectPipeline), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerProjectPipeline", reflect.TypeOf((*MockGitlab)(nil).TriggerProjectPipeline), arg0, arg1, arg2)
 }

--- a/server/gitlab/user.go
+++ b/server/gitlab/user.go
@@ -12,6 +12,7 @@ const SettingButtonsTeam = "team"
 
 type UserInfo struct {
 	UserID              string
+	Token               *oauth2.Token
 	GitlabUsername      string
 	GitlabUserID        int
 	LastToDoPostAt      int64
@@ -42,6 +43,7 @@ func (g *gitlab) GetCurrentUser(ctx context.Context, userID string, token oauth2
 	return &UserInfo{
 		UserID:         userID,
 		GitlabUserID:   gitUser.ID,
+		Token:          &token,
 		GitlabUsername: gitUser.Username,
 		LastToDoPostAt: model.GetMillis(),
 		Settings: &UserSettings{
@@ -52,8 +54,8 @@ func (g *gitlab) GetCurrentUser(ctx context.Context, userID string, token oauth2
 	}, nil
 }
 
-func (g *gitlab) GetUserDetails(ctx context.Context, user *UserInfo, token *oauth2.Token) (*internGitlab.User, error) {
-	client, err := g.GitlabConnect(*token)
+func (g *gitlab) GetUserDetails(ctx context.Context, user *UserInfo) (*internGitlab.User, error) {
+	client, err := g.GitlabConnect(*user.Token)
 	if err != nil {
 		return nil, err
 	}

--- a/server/mocks/mock_gitlab.go
+++ b/server/mocks/mock_gitlab.go
@@ -54,138 +54,138 @@ func (mr *MockGitlabMockRecorder) GetCurrentUser(arg0, arg1, arg2 interface{}) *
 }
 
 // GetGroupHooks mocks base method.
-func (m *MockGitlab) GetGroupHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 string) ([]*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) GetGroupHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 string) ([]*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGroupHooks", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetGroupHooks", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetGroupHooks indicates an expected call of GetGroupHooks.
-func (mr *MockGitlabMockRecorder) GetGroupHooks(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetGroupHooks(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupHooks", reflect.TypeOf((*MockGitlab)(nil).GetGroupHooks), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupHooks", reflect.TypeOf((*MockGitlab)(nil).GetGroupHooks), arg0, arg1, arg2)
 }
 
 // GetProject mocks base method.
-func (m *MockGitlab) GetProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3, arg4 string) (*gitlab0.Project, error) {
+func (m *MockGitlab) GetProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2, arg3 string) (*gitlab0.Project, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProject", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GetProject", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*gitlab0.Project)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProject indicates an expected call of GetProject.
-func (mr *MockGitlabMockRecorder) GetProject(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetProject(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockGitlab)(nil).GetProject), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockGitlab)(nil).GetProject), arg0, arg1, arg2, arg3)
 }
 
 // GetProjectHooks mocks base method.
-func (m *MockGitlab) GetProjectHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3, arg4 string) ([]*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) GetProjectHooks(arg0 context.Context, arg1 *gitlab.UserInfo, arg2, arg3 string) ([]*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectHooks", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GetProjectHooks", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjectHooks indicates an expected call of GetProjectHooks.
-func (mr *MockGitlabMockRecorder) GetProjectHooks(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetProjectHooks(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectHooks", reflect.TypeOf((*MockGitlab)(nil).GetProjectHooks), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectHooks", reflect.TypeOf((*MockGitlab)(nil).GetProjectHooks), arg0, arg1, arg2, arg3)
 }
 
 // GetReviews mocks base method.
-func (m *MockGitlab) GetReviews(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab.MergeRequest, error) {
+func (m *MockGitlab) GetReviews(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab.MergeRequest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReviews", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetReviews", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab.MergeRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetReviews indicates an expected call of GetReviews.
-func (mr *MockGitlabMockRecorder) GetReviews(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetReviews(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReviews", reflect.TypeOf((*MockGitlab)(nil).GetReviews), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReviews", reflect.TypeOf((*MockGitlab)(nil).GetReviews), arg0, arg1)
 }
 
 // GetUnreads mocks base method.
-func (m *MockGitlab) GetUnreads(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab0.Todo, error) {
+func (m *MockGitlab) GetUnreads(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab0.Todo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnreads", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetUnreads", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab0.Todo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUnreads indicates an expected call of GetUnreads.
-func (mr *MockGitlabMockRecorder) GetUnreads(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetUnreads(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnreads", reflect.TypeOf((*MockGitlab)(nil).GetUnreads), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnreads", reflect.TypeOf((*MockGitlab)(nil).GetUnreads), arg0, arg1)
 }
 
 // GetUserDetails mocks base method.
-func (m *MockGitlab) GetUserDetails(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) (*gitlab0.User, error) {
+func (m *MockGitlab) GetUserDetails(arg0 context.Context, arg1 *gitlab.UserInfo) (*gitlab0.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserDetails", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetUserDetails", arg0, arg1)
 	ret0, _ := ret[0].(*gitlab0.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserDetails indicates an expected call of GetUserDetails.
-func (mr *MockGitlabMockRecorder) GetUserDetails(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetUserDetails(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserDetails", reflect.TypeOf((*MockGitlab)(nil).GetUserDetails), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserDetails", reflect.TypeOf((*MockGitlab)(nil).GetUserDetails), arg0, arg1)
 }
 
 // GetYourAssignments mocks base method.
-func (m *MockGitlab) GetYourAssignments(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab.Issue, error) {
+func (m *MockGitlab) GetYourAssignments(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab.Issue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetYourAssignments", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetYourAssignments", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab.Issue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetYourAssignments indicates an expected call of GetYourAssignments.
-func (mr *MockGitlabMockRecorder) GetYourAssignments(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetYourAssignments(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourAssignments", reflect.TypeOf((*MockGitlab)(nil).GetYourAssignments), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourAssignments", reflect.TypeOf((*MockGitlab)(nil).GetYourAssignments), arg0, arg1)
 }
 
 // GetYourPrDetails mocks base method.
-func (m *MockGitlab) GetYourPrDetails(arg0 context.Context, arg1 logger.Logger, arg2 *gitlab.UserInfo, arg3 *oauth2.Token, arg4 []*gitlab.PRDetails) ([]*gitlab.PRDetails, error) {
+func (m *MockGitlab) GetYourPrDetails(arg0 context.Context, arg1 logger.Logger, arg2 *gitlab.UserInfo, arg3 []*gitlab.PRDetails) ([]*gitlab.PRDetails, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetYourPrDetails", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GetYourPrDetails", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*gitlab.PRDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetYourPrDetails indicates an expected call of GetYourPrDetails.
-func (mr *MockGitlabMockRecorder) GetYourPrDetails(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetYourPrDetails(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrDetails", reflect.TypeOf((*MockGitlab)(nil).GetYourPrDetails), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrDetails", reflect.TypeOf((*MockGitlab)(nil).GetYourPrDetails), arg0, arg1, arg2, arg3)
 }
 
 // GetYourPrs mocks base method.
-func (m *MockGitlab) GetYourPrs(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token) ([]*gitlab.MergeRequest, error) {
+func (m *MockGitlab) GetYourPrs(arg0 context.Context, arg1 *gitlab.UserInfo) ([]*gitlab.MergeRequest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetYourPrs", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetYourPrs", arg0, arg1)
 	ret0, _ := ret[0].([]*gitlab.MergeRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetYourPrs indicates an expected call of GetYourPrs.
-func (mr *MockGitlabMockRecorder) GetYourPrs(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) GetYourPrs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrs", reflect.TypeOf((*MockGitlab)(nil).GetYourPrs), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetYourPrs", reflect.TypeOf((*MockGitlab)(nil).GetYourPrs), arg0, arg1)
 }
 
 // GitlabConnect mocks base method.
@@ -204,39 +204,39 @@ func (mr *MockGitlabMockRecorder) GitlabConnect(arg0 interface{}) *gomock.Call {
 }
 
 // NewGroupHook mocks base method.
-func (m *MockGitlab) NewGroupHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 string, arg4 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) NewGroupHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 string, arg3 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewGroupHook", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "NewGroupHook", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewGroupHook indicates an expected call of NewGroupHook.
-func (mr *MockGitlabMockRecorder) NewGroupHook(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) NewGroupHook(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroupHook", reflect.TypeOf((*MockGitlab)(nil).NewGroupHook), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroupHook", reflect.TypeOf((*MockGitlab)(nil).NewGroupHook), arg0, arg1, arg2, arg3)
 }
 
 // NewProjectHook mocks base method.
-func (m *MockGitlab) NewProjectHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 interface{}, arg4 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
+func (m *MockGitlab) NewProjectHook(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 interface{}, arg3 *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewProjectHook", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "NewProjectHook", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*gitlab.WebhookInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewProjectHook indicates an expected call of NewProjectHook.
-func (mr *MockGitlabMockRecorder) NewProjectHook(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) NewProjectHook(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProjectHook", reflect.TypeOf((*MockGitlab)(nil).NewProjectHook), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProjectHook", reflect.TypeOf((*MockGitlab)(nil).NewProjectHook), arg0, arg1, arg2, arg3)
 }
 
 // ResolveNamespaceAndProject mocks base method.
-func (m *MockGitlab) ResolveNamespaceAndProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 *oauth2.Token, arg3 string, arg4 bool) (string, string, error) {
+func (m *MockGitlab) ResolveNamespaceAndProject(arg0 context.Context, arg1 *gitlab.UserInfo, arg2 string, arg3 bool) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveNamespaceAndProject", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "ResolveNamespaceAndProject", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -244,22 +244,22 @@ func (m *MockGitlab) ResolveNamespaceAndProject(arg0 context.Context, arg1 *gitl
 }
 
 // ResolveNamespaceAndProject indicates an expected call of ResolveNamespaceAndProject.
-func (mr *MockGitlabMockRecorder) ResolveNamespaceAndProject(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) ResolveNamespaceAndProject(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNamespaceAndProject", reflect.TypeOf((*MockGitlab)(nil).ResolveNamespaceAndProject), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNamespaceAndProject", reflect.TypeOf((*MockGitlab)(nil).ResolveNamespaceAndProject), arg0, arg1, arg2, arg3)
 }
 
 // TriggerProjectPipeline mocks base method.
-func (m *MockGitlab) TriggerProjectPipeline(arg0 *gitlab.UserInfo, arg1 *oauth2.Token, arg2, arg3 string) (*gitlab.PipelineInfo, error) {
+func (m *MockGitlab) TriggerProjectPipeline(arg0 *gitlab.UserInfo, arg1, arg2 string) (*gitlab.PipelineInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TriggerProjectPipeline", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "TriggerProjectPipeline", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*gitlab.PipelineInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TriggerProjectPipeline indicates an expected call of TriggerProjectPipeline.
-func (mr *MockGitlabMockRecorder) TriggerProjectPipeline(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockGitlabMockRecorder) TriggerProjectPipeline(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerProjectPipeline", reflect.TypeOf((*MockGitlab)(nil).TriggerProjectPipeline), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerProjectPipeline", reflect.TypeOf((*MockGitlab)(nil).TriggerProjectPipeline), arg0, arg1, arg2)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -18,11 +18,9 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
-	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
 	"github.com/mattermost/mattermost/server/public/pluginapi/experimental/bot/poster"
 	"github.com/mattermost/mattermost/server/public/pluginapi/experimental/telemetry"
 	"github.com/pkg/errors"
-	gitlabLib "github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
 
@@ -32,10 +30,7 @@ import (
 )
 
 const (
-	GitlabUserInfoKey             = "_userinfo"
-	GitlabUserTokenKey            = "_usertoken"
-	GitlabMigrationTokenKey       = "_gitlabtoken"
-	TokenMutexKey                 = "-oauth-token" //#nosec G101 -- False positive
+	GitlabTokenKey                = "_gitlabtoken"
 	GitlabUsernameKey             = "_gitlabusername"
 	GitlabIDUsernameKey           = "_gitlabidusername"
 	WsEventConnect                = "gitlab_connect"
@@ -48,8 +43,6 @@ const (
 	SettingOff                    = "off"
 
 	chimeraGitLabAppIdentifier = "plugin-gitlab"
-
-	invalidTokenError = "401 {error: invalid_token}" //#nosec G101 -- False positive
 )
 
 var manifest model.Manifest = root.Manifest
@@ -195,21 +188,13 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 		return nil, ""
 	}
 
-	var glClient *gitlabLib.Client
-	if cErr := p.useGitlabClient(info, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GitlabConnect(*token)
-		if err != nil {
-			return err
-		}
-
-		glClient = resp
-		return nil
-	}); cErr != nil {
+	client, cErr := p.GitlabClient.GitlabConnect(*info.Token)
+	if cErr != nil {
 		p.API.LogDebug("Error in getting GitLab client", "Error", cErr.Error())
 		return nil, ""
 	}
 
-	post.Message = p.makeReplacements(msg, replacements, glClient)
+	post.Message = p.makeReplacements(msg, replacements, client)
 	return post, ""
 }
 
@@ -291,32 +276,21 @@ func (p *Plugin) getOAuthConfigForChimeraApp(scopes []string, redirectURL string
 }
 
 func (p *Plugin) storeGitlabUserInfo(info *gitlab.UserInfo) error {
+	config := p.getConfiguration()
+
+	encryptedToken, err := encrypt([]byte(config.EncryptionKey), info.Token.AccessToken)
+	if err != nil {
+		return err
+	}
+
+	info.Token.AccessToken = encryptedToken
+
 	jsonInfo, err := json.Marshal(info)
 	if err != nil {
 		return err
 	}
 
-	if _, err := p.client.KV.Set(info.UserID+GitlabUserInfoKey, jsonInfo); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (p *Plugin) storeGitlabUserToken(userID string, token *oauth2.Token) error {
-	config := p.getConfiguration()
-
-	jsonToken, err := json.Marshal(token)
-	if err != nil {
-		return err
-	}
-
-	encryptedToken, err := encrypt([]byte(config.EncryptionKey), string(jsonToken))
-	if err != nil {
-		return err
-	}
-
-	if _, err := p.client.KV.Set(userID+GitlabUserTokenKey, []byte(encryptedToken)); err != nil {
+	if _, err := p.client.KV.Set(info.UserID+GitlabTokenKey, jsonInfo); err != nil {
 		return err
 	}
 
@@ -324,117 +298,43 @@ func (p *Plugin) storeGitlabUserToken(userID string, token *oauth2.Token) error 
 }
 
 func (p *Plugin) deleteGitlabUserInfo(userID string) error {
-	if err := p.client.KV.Delete(userID + GitlabUserInfoKey); err != nil {
+	if err := p.client.KV.Delete(userID + GitlabTokenKey); err != nil {
 		return errors.Wrap(err, "encountered error deleting GitLab user info")
 	}
 	return nil
 }
 
-func (p *Plugin) deleteGitlabUserToken(userID string) error {
-	if err := p.client.KV.Delete(userID + GitlabUserTokenKey); err != nil {
-		return errors.Wrap(err, "encountered error deleting GitLab user token")
-	}
-	return nil
-}
-
 func (p *Plugin) getGitlabUserInfoByMattermostID(userID string) (*gitlab.UserInfo, *APIErrorResponse) {
+	config := p.getConfiguration()
+
 	var userInfo gitlab.UserInfo
-
-	var infoBytes []byte
-	err := p.client.KV.Get(userID+GitlabUserInfoKey, &infoBytes)
-
-	if err != nil || infoBytes == nil {
-		var gitlabTokenBytes []byte
-		appErr := p.client.KV.Get(userID+GitlabMigrationTokenKey, &gitlabTokenBytes)
-		if appErr != nil || gitlabTokenBytes == nil {
-			return nil, &APIErrorResponse{ID: APIErrorIDNotConnected, Message: "Must connect user account to GitLab first.", StatusCode: http.StatusBadRequest}
-		}
-		if err := json.Unmarshal(gitlabTokenBytes, &userInfo); err != nil {
-			return nil, &APIErrorResponse{ID: "", Message: "Unable to parse user info from migration key.", StatusCode: http.StatusInternalServerError}
-		}
-	} else if err := json.Unmarshal(infoBytes, &userInfo); err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to parse user info.", StatusCode: http.StatusInternalServerError}
-	}
-
-	return &userInfo, nil
-}
-
-func (p *Plugin) migrateGitlabToken(userID string) (*oauth2.Token, *APIErrorResponse) {
-	config := p.getConfiguration()
-
-	var userInfo struct {
-		gitlab.UserInfo
-		Token *oauth2.Token
-	}
-
-	mutex, err := cluster.NewMutex(p.API, userID+TokenMutexKey)
-	if err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to obtain mutex for KV migration.", StatusCode: http.StatusInternalServerError}
-	}
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	var gitlabTokenBytes []byte
-	err = p.client.KV.Get(userID+GitlabMigrationTokenKey, &gitlabTokenBytes)
-	if err != nil || gitlabTokenBytes == nil {
-		return p.getGitlabUserTokenByMattermostID(userID)
-	}
-
-	if err = json.Unmarshal(gitlabTokenBytes, &userInfo); err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to parse user info for KV migration.", StatusCode: http.StatusInternalServerError}
-	}
-
-	unencryptedToken, err := decrypt([]byte(config.EncryptionKey), userInfo.Token.AccessToken)
-	if err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to decrypt token for KV migration.", StatusCode: http.StatusInternalServerError}
-	}
-
-	userInfo.Token.AccessToken = unencryptedToken
-
-	var userInfoWithoutToken = &gitlab.UserInfo{
-		UserID:         userInfo.UserID,
-		GitlabUserID:   userInfo.GitlabUserID,
-		GitlabUsername: userInfo.GitlabUsername,
-		LastToDoPostAt: userInfo.LastToDoPostAt,
-		Settings:       userInfo.Settings,
-	}
-
-	if err = p.storeGitlabUserInfo(userInfoWithoutToken); err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to store user info for KV migration.", StatusCode: http.StatusInternalServerError}
-	}
-
-	if err = p.storeGitlabUserToken(userInfo.UserID, userInfo.Token); err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to store token for KV migration.", StatusCode: http.StatusInternalServerError}
-	}
-
-	if err = p.client.KV.Delete(userInfo.UserID + GitlabMigrationTokenKey); err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to delete KV entry for migration.", StatusCode: http.StatusInternalServerError}
-	}
-
-	return userInfo.Token, nil
-}
-
-func (p *Plugin) getGitlabUserTokenByMattermostID(userID string) (*oauth2.Token, *APIErrorResponse) {
-	config := p.getConfiguration()
-	var token oauth2.Token
-
-	var tokenBytes []byte
-	err := p.client.KV.Get(userID+GitlabUserTokenKey, &tokenBytes)
-	if err != nil || tokenBytes == nil {
+	if err := p.client.KV.Get(userID+GitlabTokenKey, &userInfo); err != nil || userInfo.Token == nil {
 		return nil, &APIErrorResponse{ID: APIErrorIDNotConnected, Message: "Must connect user account to GitLab first.", StatusCode: http.StatusBadRequest}
 	}
 
-	unencryptedToken, err := decrypt([]byte(config.EncryptionKey), string(tokenBytes))
+	unencryptedToken, err := decrypt([]byte(config.EncryptionKey), userInfo.Token.AccessToken)
 	if err != nil {
 		p.client.Log.Warn("can't decrypt token", "err", err.Error())
 		return nil, &APIErrorResponse{ID: "", Message: "Unable to decrypt access token.", StatusCode: http.StatusInternalServerError}
 	}
 
-	if err := json.Unmarshal([]byte(unencryptedToken), &token); err != nil {
-		return nil, &APIErrorResponse{ID: "", Message: "Unable to parse token.", StatusCode: http.StatusInternalServerError}
+	userInfo.Token.AccessToken = unencryptedToken
+	newToken, err := p.checkAndRefreshToken(userInfo.Token)
+	if err != nil {
+		return nil, &APIErrorResponse{ID: "", Message: err.Error(), StatusCode: http.StatusInternalServerError}
 	}
 
-	return &token, nil
+	if newToken != nil {
+		p.client.Log.Debug("Gitlab token refreshed.", "UserID", userInfo.UserID, "Gitlab Username", userInfo.GitlabUsername)
+		userInfo.Token = newToken
+		unencryptedToken = newToken.AccessToken // needed because the storeGitlabUserInfo method changes its value to an encrypted value
+		if err := p.storeGitlabUserInfo(&userInfo); err != nil {
+			return nil, &APIErrorResponse{ID: "", Message: fmt.Sprintf("Unable to store user info. Error: %s", err.Error()), StatusCode: http.StatusInternalServerError}
+		}
+		userInfo.Token.AccessToken = unencryptedToken
+	}
+
+	return &userInfo, nil
 }
 
 func (p *Plugin) storeGitlabToUserIDMapping(gitlabUsername, userID string) error {
@@ -494,9 +394,6 @@ func (p *Plugin) disconnectGitlabAccount(userID string) {
 	}
 
 	if err := p.deleteGitlabUserInfo(userID); err != nil {
-		p.client.Log.Warn("can't delete user info in store", "err", err.Error, "userId", userID)
-	}
-	if err := p.deleteGitlabUserToken(userID); err != nil {
 		p.client.Log.Warn("can't delete token in store", "err", err.Error, "userId", userID)
 	}
 	if err := p.deleteGitlabToUserIDMapping(userInfo.GitlabUsername); err != nil {
@@ -571,19 +468,12 @@ func (p *Plugin) PostToDo(ctx context.Context, info *gitlab.UserInfo) {
 
 func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, string, error) {
 	hasTodo := false
+
 	g, ctx := errgroup.WithContext(ctx)
 
 	notificationText := ""
 	g.Go(func() error {
-		var unreads []*gitlabLib.Todo
-		err := p.useGitlabClient(user, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-			resp, err := p.GitlabClient.GetUnreads(ctx, info, token)
-			if err != nil {
-				return err
-			}
-			unreads = resp
-			return nil
-		})
+		unreads, err := p.GitlabClient.GetUnreads(ctx, user)
 		if err != nil {
 			return err
 		}
@@ -617,15 +507,7 @@ func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, stri
 
 	reviewText := ""
 	g.Go(func() error {
-		var reviews []*gitlab.MergeRequest
-		err := p.useGitlabClient(user, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-			resp, err := p.GitlabClient.GetReviews(ctx, info, token)
-			if err != nil {
-				return err
-			}
-			reviews = resp
-			return nil
-		})
+		reviews, err := p.GitlabClient.GetReviews(ctx, user)
 		if err != nil {
 			return err
 		}
@@ -647,15 +529,7 @@ func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, stri
 
 	assignmentText := ""
 	g.Go(func() error {
-		var yourAssignments []*gitlab.Issue
-		err := p.useGitlabClient(user, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-			resp, err := p.GitlabClient.GetYourAssignments(ctx, info, token)
-			if err != nil {
-				return err
-			}
-			yourAssignments = resp
-			return nil
-		})
+		yourAssignments, err := p.GitlabClient.GetYourAssignments(ctx, user)
 		if err != nil {
 			return err
 		}
@@ -677,15 +551,7 @@ func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, stri
 
 	mergeRequestText := ""
 	g.Go(func() error {
-		var mergeRequests []*gitlab.MergeRequest
-		err := p.useGitlabClient(user, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-			resp, err := p.GitlabClient.GetYourPrs(ctx, info, token)
-			if err != nil {
-				return err
-			}
-			mergeRequests = resp
-			return nil
-		})
+		mergeRequests, err := p.GitlabClient.GetYourPrs(ctx, user)
 		if err != nil {
 			return err
 		}
@@ -772,15 +638,7 @@ func (p *Plugin) sendChannelSubscriptionsUpdated(subs *Subscriptions, channelID 
 // HasProjectHook checks if the subscribed GitLab Project or its parrent Group has a webhook
 // with a URL that matches the Mattermost Site URL.
 func (p *Plugin) HasProjectHook(ctx context.Context, user *gitlab.UserInfo, namespace string, project string) (bool, error) {
-	var hooks []*gitlab.WebhookInfo
-	err := p.useGitlabClient(user, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetProjectHooks(ctx, info, token, namespace, project)
-		if err != nil {
-			return err
-		}
-		hooks = resp
-		return nil
-	})
+	hooks, err := p.GitlabClient.GetProjectHooks(ctx, user, namespace, project)
 	if err != nil {
 		return false, errors.New("unable to connect to GitLab")
 	}
@@ -806,15 +664,7 @@ func (p *Plugin) HasProjectHook(ctx context.Context, user *gitlab.UserInfo, name
 // HasGroupHook checks if the subscribed GitLab Group has a webhook
 // with a URL that matches the Mattermost Site URL.
 func (p *Plugin) HasGroupHook(ctx context.Context, user *gitlab.UserInfo, namespace string) (bool, error) {
-	var hooks []*gitlab.WebhookInfo
-	err := p.useGitlabClient(user, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetGroupHooks(ctx, info, token, namespace)
-		if err != nil {
-			return err
-		}
-		hooks = resp
-		return nil
-	})
+	hooks, err := p.GitlabClient.GetGroupHooks(ctx, user, namespace)
 	if err != nil {
 		return false, errors.New("unable to connect to GitLab")
 	}
@@ -831,91 +681,22 @@ func (p *Plugin) HasGroupHook(ctx context.Context, user *gitlab.UserInfo, namesp
 	return found, err
 }
 
-func (p *Plugin) refreshToken(userInfo *gitlab.UserInfo, token *oauth2.Token) (*oauth2.Token, error) {
-	conf := p.getOAuthConfig()
-	src := conf.TokenSource(context.Background(), token)
-
-	newToken, err := src.Token() // this actually goes and renews the tokens
-
-	if err != nil {
-		if strings.Contains(err.Error(), "\"error\":\"invalid_grant\"") {
-			p.handleRevokedToken(userInfo)
+func (p *Plugin) checkAndRefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
+	// If there is only one minute left for the token to expire, we are refreshing the token.
+	// The detailed reason for this can be found here: https://github.com/golang/oauth2/issues/84#issuecomment-831492464
+	// We don't want the token to expire between the time when we decide that the old token is valid
+	// and the time at which we create the request. We are handling that by not letting the token expire.
+	if time.Until(token.Expiry) <= 1*time.Minute {
+		conf := p.getOAuthConfig()
+		src := conf.TokenSource(context.Background(), token)
+		newToken, err := src.Token() // this actually goes and renews the tokens
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get the new refreshed token")
 		}
-		return nil, errors.Wrap(err, "unable to get the new refreshed token")
-	}
-
-	if newToken.AccessToken != token.AccessToken {
-		p.client.Log.Debug("Gitlab token refreshed.", "UserID", userInfo.UserID)
-
-		if err := p.storeGitlabUserToken(userInfo.UserID, newToken); err != nil {
-			return nil, errors.Wrap(err, "unable to store user info with refreshed token")
-		}
-
-		return newToken, nil
-	}
-
-	return token, nil
-}
-
-func (p *Plugin) handleRevokedToken(info *gitlab.UserInfo) {
-	p.disconnectGitlabAccount(info.UserID)
-	err := p.CreateBotDMPost(info.UserID, "Your GitLab account was disconnected due to an invalid or revoked authorization token. Reconnect your account using the `/gitlab connect` command.", "custom_git_revoked_token")
-
-	if err != nil {
-		p.client.Log.Warn("Error sending revoked token DM post", "err", err.Error())
-	}
-}
-
-func (p *Plugin) getOrRefreshTokenWithMutex(info *gitlab.UserInfo) (*oauth2.Token, error) {
-	token, apiErr := p.getGitlabUserTokenByMattermostID(info.UserID)
-
-	if apiErr != nil {
-		token, apiErr = p.migrateGitlabToken(info.UserID)
-		if apiErr != nil {
-			return nil, apiErr
+		if newToken.AccessToken != token.AccessToken {
+			return newToken, nil
 		}
 	}
 
-	if time.Until(token.Expiry) > 1*time.Minute {
-		return token, nil
-	}
-
-	mutex, err := cluster.NewMutex(p.API, info.UserID+TokenMutexKey)
-	if err != nil {
-		return nil, err
-	}
-
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	lockedToken, apiErr := p.getGitlabUserTokenByMattermostID(info.UserID)
-	if apiErr != nil {
-		return nil, apiErr
-	}
-
-	if time.Until(lockedToken.Expiry) > 1*time.Minute {
-		return lockedToken, nil
-	}
-
-	newToken, err := p.refreshToken(info, lockedToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return newToken, nil
-}
-
-func (p *Plugin) useGitlabClient(info *gitlab.UserInfo, toRun func(info *gitlab.UserInfo, token *oauth2.Token) error) error {
-	token, err := p.getOrRefreshTokenWithMutex(info)
-	if err != nil {
-		return err
-	}
-
-	err = toRun(info, token)
-
-	if err != nil && strings.Contains(err.Error(), invalidTokenError) {
-		p.handleRevokedToken(info)
-	}
-
-	return err
+	return nil, nil
 }

--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -49,7 +49,7 @@ func (p *Plugin) SendDailyTelemetry() {
 
 func (p *Plugin) getConnectedUserCount() (int64, error) {
 	checker := func(key string) (keep bool, err error) {
-		return strings.HasSuffix(key, GitlabUserInfoKey), nil
+		return strings.HasSuffix(key, GitlabTokenKey), nil
 	}
 
 	var count int64

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	gitlabLib "github.com/xanzy/go-gitlab"
-	"golang.org/x/oauth2"
 
 	"github.com/mattermost/mattermost-plugin-gitlab/server/gitlab"
 	"github.com/mattermost/mattermost-plugin-gitlab/server/subscription"
@@ -208,16 +207,7 @@ func (p *Plugin) permissionToProject(ctx context.Context, userID, namespace, pro
 		return false
 	}
 
-	var result *gitlabLib.Project
-	err := p.useGitlabClient(info, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.GetProject(ctx, info, token, namespace, project)
-		if err != nil {
-			return err
-		}
-		result = resp
-		return nil
-	})
-	if result == nil || err != nil {
+	if result, err := p.GitlabClient.GetProject(ctx, info, namespace, project); result == nil || err != nil {
 		if err != nil {
 			p.client.Log.Warn("can't get project in webhook", "err", err.Error(), "project", namespace+"/"+project)
 		}
@@ -226,47 +216,22 @@ func (p *Plugin) permissionToProject(ctx context.Context, userID, namespace, pro
 	return true
 }
 
-func (p *Plugin) createHook(ctx context.Context, gitlabClient gitlab.Gitlab, info *gitlab.UserInfo, group, project string, hookOptions *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
+func CreateHook(ctx context.Context, gitlabClient gitlab.Gitlab, info *gitlab.UserInfo, group, project string, hookOptions *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error) {
 	// If project scope
 	if project != "" {
-		var gitProject *gitlabLib.Project
-		getProjectErr := p.useGitlabClient(info, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-			resp, err := p.GitlabClient.GetProject(ctx, info, token, group, project)
-			if err != nil {
-				return err
-			}
-			gitProject = resp
-			return nil
-		})
-		if getProjectErr != nil {
-			return nil, getProjectErr
+		project, err := gitlabClient.GetProject(ctx, info, group, project)
+		if err != nil {
+			return nil, err
 		}
-		var newWebhook *gitlab.WebhookInfo
-		getGroupErr := p.useGitlabClient(info, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-			resp, err := p.GitlabClient.NewProjectHook(ctx, info, token, gitProject.ID, hookOptions)
-			if err != nil {
-				return err
-			}
-			newWebhook = resp
-			return nil
-		})
-		if getGroupErr != nil {
-			return nil, getGroupErr
+		newWebhook, err := gitlabClient.NewProjectHook(ctx, info, project.ID, hookOptions)
+		if err != nil {
+			return nil, err
 		}
 		return newWebhook, nil
 	}
 
 	// If webhook is group scoped
-	var newWebhook *gitlab.WebhookInfo
-	err := p.useGitlabClient(info, func(info *gitlab.UserInfo, token *oauth2.Token) error {
-		resp, err := p.GitlabClient.NewGroupHook(ctx, info, token, group, hookOptions)
-		if err != nil {
-			return err
-		}
-		newWebhook = resp
-		return nil
-	})
-
+	newWebhook, err := gitlabClient.NewGroupHook(ctx, info, group, hookOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Summary

This PR reverts https://github.com/mattermost/mattermost-plugin-gitlab/pull/308 to resolve the issue linked below, seemingly introduced by that PR based on the issue's error message, since that is when we introduced the usage of `cluster.Mutex`.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/396