### PR TITLE
[GH-400] Display proper message for access request todo

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -46,8 +46,9 @@ const (
 	SettingReminders              = "reminders"
 	SettingOn                     = "on"
 	SettingOff                    = "off"
+	chimeraGitLabAppIdentifier    = "plugin-gitlab"
 
-	chimeraGitLabAppIdentifier = "plugin-gitlab"
+	ActionNameMemberAccessRequest = "member_access_requested"
 
 	invalidTokenError = "401 {error: invalid_token}" //#nosec G101 -- False positive
 )
@@ -606,7 +607,14 @@ func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, stri
 				continue
 			}
 			notificationCount++
-			notificationContent += fmt.Sprintf("* %v : [%v](%v)\n", n.ActionName, n.Target.Title, n.TargetURL)
+
+			switch n.ActionName {
+			// Handling this cases specifically as the "Title" field is empty in this case
+			case ActionNameMemberAccessRequest:
+				notificationContent += fmt.Sprintf("* %v : [%v](%v) has requested access to [%v](%v)\n", n.ActionName, n.Author.Name, n.Author.WebURL, n.Body, n.TargetURL)
+			default:
+				notificationContent += fmt.Sprintf("* %v : [%v](%v)\n", n.ActionName, n.Target.Title, n.TargetURL)
+			}
 		}
 
 		if notificationCount == 0 {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -46,9 +46,10 @@ const (
 	SettingReminders              = "reminders"
 	SettingOn                     = "on"
 	SettingOff                    = "off"
-	chimeraGitLabAppIdentifier    = "plugin-gitlab"
 
-	ActionNameMemberAccessRequest = "member_access_requested"
+	chimeraGitLabAppIdentifier = "plugin-gitlab"
+
+	NotificationActionNameMemberAccessRequest = "member_access_requested"
 
 	invalidTokenError = "401 {error: invalid_token}" //#nosec G101 -- False positive
 )
@@ -609,8 +610,8 @@ func (p *Plugin) GetToDo(ctx context.Context, user *gitlab.UserInfo) (bool, stri
 			notificationCount++
 
 			switch n.ActionName {
-			// Handling this cases specifically as the "Title" field is empty in this case
-			case ActionNameMemberAccessRequest:
+			// Handle special cases where the provided "Title" value is blank
+			case NotificationActionNameMemberAccessRequest:
 				notificationContent += fmt.Sprintf("* %v : [%v](%v) has requested access to [%v](%v)\n", n.ActionName, n.Author.Name, n.Author.WebURL, n.Body, n.TargetURL)
 			default:
 				notificationContent += fmt.Sprintf("* %v : [%v](%v)\n", n.ActionName, n.Target.Title, n.TargetURL)


### PR DESCRIPTION
#### Summary
The description of the "member_access_requested" todo was not being displayed, we handled the case specifically and added a proper description.

#### Screenshots
Earlier: 
![image](https://github.com/Brightscout/mattermost-plugin-gitlab/assets/55234496/c2627da3-990c-4910-81c0-684eddf623c0)

Now:
![image](https://github.com/Brightscout/mattermost-plugin-gitlab/assets/55234496/74a35859-6088-4544-9c8a-b9f9937ba68d)

#### What to test:
- Todos are properly displayed for "member_access_requested".

###### Steps to reproduce:
1. Connect your Gitlab account.
2. Request access to one of your projects/groups from any other user. You will get a todo/notification on Gitlab for access request. 
3. Run the `/gitlab todo` command on Mattermost. You should get a post containing the todos.

###### Expected behavior:
- The "member_access_requested" todo should have a proper description.

###### Environment:
GitLab Plugin version: 1.7.0
MM version: v7.8.2

#### Ticket Link
Fixes #400 

