### PR TITLE
[GH-329] Fix issue: Image attachment breaking in comment notification

### DIFF
--- a/server/webhook/note.go
+++ b/server/webhook/note.go
@@ -42,7 +42,7 @@ func (w *webhook) handleDMIssueComment(event *gitlab.IssueCommentEvent) ([]*Hand
 		pathWithNamespace: event.Project.PathWithNamespace,
 		IID:               fmt.Sprintf("%d", event.Issue.IID),
 		URL:               event.ObjectAttributes.URL,
-		body:              event.ObjectAttributes.Note,
+		body:              event.ObjectAttributes.Description,
 	}); mention != nil {
 		handlers = append(handlers, mention)
 	}
@@ -53,7 +53,7 @@ func (w *webhook) handleDMIssueComment(event *gitlab.IssueCommentEvent) ([]*Hand
 func (w *webhook) handleChannelIssueComment(ctx context.Context, event *gitlab.IssueCommentEvent) ([]*HandleWebhook, error) {
 	senderGitlabUsername := event.User.Username
 	repo := event.Project
-	body := event.ObjectAttributes.Note
+	body := event.ObjectAttributes.Description
 	res := []*HandleWebhook{}
 
 	message := fmt.Sprintf("[%s](%s) New comment by [%s](%s) on [#%v %s](%s):\n\n%s", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Issue.IID, event.Issue.Title, event.ObjectAttributes.URL, body)
@@ -113,7 +113,7 @@ func (w *webhook) handleDMMergeRequestComment(event *gitlab.MergeCommentEvent) (
 		pathWithNamespace: event.Project.PathWithNamespace,
 		IID:               fmt.Sprintf("%d", event.MergeRequest.IID),
 		URL:               event.ObjectAttributes.URL,
-		body:              event.ObjectAttributes.Note,
+		body:              event.ObjectAttributes.Description,
 	}); mention != nil {
 		handlers = append(handlers, mention)
 	}
@@ -123,7 +123,7 @@ func (w *webhook) handleDMMergeRequestComment(event *gitlab.MergeCommentEvent) (
 func (w *webhook) handleChannelMergeRequestComment(ctx context.Context, event *gitlab.MergeCommentEvent) ([]*HandleWebhook, error) {
 	senderGitlabUsername := event.User.Username
 	repo := event.Project
-	body := event.ObjectAttributes.Note
+	body := event.ObjectAttributes.Description
 	res := []*HandleWebhook{}
 
 	message := fmt.Sprintf("[%s](%s) New comment by [%s](%s) on [#%v %s](%s):\n\n%s", repo.PathWithNamespace, repo.WebURL, senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.MergeRequest.IID, event.MergeRequest.Title, event.ObjectAttributes.URL, body)


### PR DESCRIPTION
#### Summary
- The image attachments were not getting rendered in the issue/merge request comment notification because of an invalid attachment link. I updated the code to use the proper link present in the payload. 

- This PR is an updated version of PR [#330](https://github.com/mattermost/mattermost-plugin-gitlab/pull/330).

#### Screenshots
Earlier:
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/55234496/81ebd5f0-8b2a-43e9-bf85-37376b11a233)

Now:
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/55234496/cfcfa9d0-db47-4a1a-94d0-5d47500b1e43)

#### What to test?
Image attachments are getting rendered properly in the issue/merge request comment notification.

###### Steps to reproduce:
1. Connect your GitLab account.
2. Create a subscription of type 'issue_comments' and 'merge_request_comments' by using the slash command.
3. Trigger an event of the desired type on Gitlab.

###### Environment:
MM version: v7.8.2
Node version: 14.18.0
Go version: 1.19.0

#### Ticket Link

Fixes #329 