### PR TITLE
[GH-383] Fix UX for member_access_request in right hand sidebar

### DIFF
--- a/webapp/src/components/sidebar_right/gitlab_items.tsx
+++ b/webapp/src/components/sidebar_right/gitlab_items.tsx
@@ -20,10 +20,12 @@ export const notificationReasons: Record<string | symbol, string> = {
     approval_required: 'Your approval is required on this issue/merge request.',
     unmergeable: 'This merge request can\'t be merged.',
     merge_train_removed: 'A merge train was removed.',
+    member_access_requested: 'requested access to a project/group.'
 };
 
 const SUCCESS = 'success';
 const PENDING = 'pending';
+const ACTION_NAME_MEMBER_ACCESS_REQUESTED = 'member_access_requested';
 
 function GitlabItems({item, theme}: GitlabItemsProps) {
     const style = getStyle(theme);
@@ -48,7 +50,7 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
         );
     }
 
-    const titleText = item.title || item.target?.title || '';
+    const titleText = item.title || item.target?.title || item.body || '';
 
     let title: React.ReactNode = titleText;
     if (item.web_url || item.target_url) {
@@ -174,17 +176,14 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
             </div>
             <div>
                 {number}
-                <span className='light'>{repoName}</span>
+                {repoName && <span className='light'>({repoName})</span>}
             </div>
             {labels}
             <div
                 className='light'
                 style={style.subtitle}
             >
-                {'Opened'}
                 {item.created_at && ` ${formatTimeSince(item.created_at)} ago`}
-                {userName && ` by ${userName}`}
-                {'.'}
                 {milestone}
             </div>
             <div
@@ -194,7 +193,7 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
                 {item.action_name && (
                     <>
                         <div>{item.updated_at && `Updated ${formatTimeSince(item.updated_at)} ago.`}</div>
-                        {notificationReasons[item.action_name]}
+                        {item.action_name == ACTION_NAME_MEMBER_ACCESS_REQUESTED && <a href={item.author.web_url}>{item.author.name}</a>} {notificationReasons[item.action_name]}
                     </>
                 )}
             </div>

--- a/webapp/src/components/sidebar_right/gitlab_items.tsx
+++ b/webapp/src/components/sidebar_right/gitlab_items.tsx
@@ -162,6 +162,8 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
         );
     }
 
+    const includeNotificationAuthor = item.action_name == ACTION_NAME_MEMBER_ACCESS_REQUESTED;
+
     return (
         <div
             key={item.id}
@@ -183,7 +185,9 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
                 className='light'
                 style={style.subtitle}
             >
+                {!item.action_name && 'Opened'}
                 {item.created_at && ` ${formatTimeSince(item.created_at)} ago`}
+                {!item.action_name && userName && ` by ${userName}.`}
                 {milestone}
             </div>
             <div
@@ -193,7 +197,8 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
                 {item.action_name && (
                     <>
                         <div>{item.updated_at && `Updated ${formatTimeSince(item.updated_at)} ago.`}</div>
-                        {item.action_name == ACTION_NAME_MEMBER_ACCESS_REQUESTED && <a href={item.author.web_url}>{item.author.name}</a>} {notificationReasons[item.action_name]}
+                        {includeNotificationAuthor && <a href={item.author.web_url}>{item.author.name} </a>}
+                        {notificationReasons[item.action_name]}
                     </>
                 )}
             </div>

--- a/webapp/src/types/gitlab_items.ts
+++ b/webapp/src/types/gitlab_items.ts
@@ -11,6 +11,8 @@ export interface Label {
 
 export interface User {
     username: string;
+    web_url: string;
+    name: string;
 }
 
 export interface References {
@@ -57,6 +59,7 @@ export interface Item {
     num_approvers: number;
     total_reviewers: number;
     reviewers: User[];
+    body: string;
 }
 
 export interface GitlabItemsProps {


### PR DESCRIPTION
#### Summary
- Fixed the UI for the "member_access_request" type todo/unread in RHS
- A PR #404 is already open to fix the UX gap for todos posted after running the `/gitlab todo` command.

#### Screenshots
![image](https://github.com/Brightscout/mattermost-plugin-gitlab/assets/55234496/09c4197c-f5b8-4add-b7ec-c030767e7e9f)

#### What to test?
- ToDos of type "member_access_request" are rendered properly in the RHS.

###### Steps to reproduce:
1. Connect your Gitlab account.
2. Generate a notification of type "member_access_request" on the Gitlab side. (You can do so by making an access request to one of your project/group by some another user)
3. Open the RHS for todos/unreads.

###### Environment:
MM version: v7.8.2
Node version: 14.18.0
Go version: 1.19.0

#### Ticket Link
Fixes #383 
