### PR TITLE
[MI-3589] Added config setting to enable/disable child pipeline notfication

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -90,6 +90,14 @@
                 "default": null
             },
             {
+                "key": "EnableChildPipelineNotifications",
+                "display_name": "Enable Child Pipelines Notification:",
+                "type": "bool",
+                "help_text": "(Optional) Allow the plugin to post notfication for child pipelines when the pipeline subscription is created in a channel.",
+                "placeholder": "",
+                "default": true
+            },
+            {
                 "key": "EnableCodePreview",
                 "display_name": "Enable Code Previews:",
                 "type": "dropdown",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -27,15 +27,16 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	GitlabURL                   string `json:"gitlaburl"`
-	GitlabOAuthClientID         string `json:"gitlaboauthclientid"`
-	GitlabOAuthClientSecret     string `json:"gitlaboauthclientsecret"`
-	WebhookSecret               string `json:"webhooksecret"`
-	EncryptionKey               string `json:"encryptionkey"`
-	GitlabGroup                 string `json:"gitlabgroup"`
-	EnablePrivateRepo           bool   `json:"enableprivaterepo"`
-	EnableCodePreview           string `json:"enablecodepreview"`
-	UsePreregisteredApplication bool   `json:"usepreregisteredapplication"`
+	GitlabURL                        string `json:"gitlaburl"`
+	GitlabOAuthClientID              string `json:"gitlaboauthclientid"`
+	GitlabOAuthClientSecret          string `json:"gitlaboauthclientsecret"`
+	WebhookSecret                    string `json:"webhooksecret"`
+	EncryptionKey                    string `json:"encryptionkey"`
+	GitlabGroup                      string `json:"gitlabgroup"`
+	EnablePrivateRepo                bool   `json:"enableprivaterepo"`
+	EnableCodePreview                string `json:"enablecodepreview"`
+	UsePreregisteredApplication      bool   `json:"usepreregisteredapplication"`
+	EnableChildPipelineNotifications bool   `json:"enablechildpipelinenotifications"`
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	webhookTimeout = 10 * time.Second
+	webhookTimeout            = 10 * time.Second
+	eventSourceParentPipeline = "parent_pipeline"
 )
 
 type gitlabRetreiver struct {
@@ -118,6 +119,10 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		repoPrivate = event.Project.Visibility == gitlabLib.PrivateVisibility
 		pathWithNamespace = event.Project.PathWithNamespace
 		fromUser = event.User.Username
+		if !p.configuration.EnableChildPipelineNotifications && event.ObjectAttributes.Source == eventSourceParentPipeline {
+			return
+		}
+
 		handlers, errHandler = p.WebhookHandler.HandlePipeline(ctx, event)
 	case *gitlabLib.JobEvent:
 		repoPrivate = event.Repository.Visibility == gitlabLib.PrivateVisibility


### PR DESCRIPTION
#### Summary
When a pipeline with many child pipelines is triggered on Gitlab and the user has a subscription for "pipeline" in a channel, the channel gets flooded with many notifications. We added a config setting to enable/disable notification for child pipelines.
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/55234496/ec02404c-7bcb-4bc8-8ce3-55a4f4d1619a)

#### Screenshots
When enabled:
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/55234496/8ba98688-e6b1-4942-8891-2401f9f3ce4c)

When disabled:
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/55234496/7f2afba7-95d3-49bf-8e5b-112e9c601b8c)

#### What to test?
- Not getting notifications for child pipelines when config setting `EnableChildPipelineNotifications` is disabled.

###### Steps to reproduce:
1. Connet your Gitlab account.
2. Create a subscription for "pipeline" in a channel.
3. Set up a child pipeline workflow on the project you have created a subscription for. ([How to setup child pipeline](https://medium.com/ovrsea/how-to-use-parent-child-pipelines-on-gitlab-ci-658e946ebdb6))
4. Trigger the pipeline and wait for it to complete.

###### Environment:
MM version: v7.8.2
Node version: 14.18.0
Go version: 1.19.0

#### Ticket Link
Fixes #320 