### PR TITLE
Support client secret values longer than 64 characters

### DIFF
--- a/server/flow.go
+++ b/server/flow.go
@@ -509,10 +509,6 @@ func (fm *FlowManager) submitOAuthConfig(f *flow.Flow, submitted map[string]inte
 
 	clientID = strings.TrimSpace(clientID)
 
-	if len(clientID) < 64 {
-		errorList["client_id"] = "Client ID should be at least 64 characters long"
-	}
-
 	clientSecretRaw, ok := submitted["client_secret"]
 	if !ok {
 		return "", nil, nil, errors.New("client_secret missing")
@@ -523,10 +519,6 @@ func (fm *FlowManager) submitOAuthConfig(f *flow.Flow, submitted map[string]inte
 	}
 
 	clientSecret = strings.TrimSpace(clientSecret)
-
-	if len(clientSecret) < 64 {
-		errorList["client_secret"] = "Client Secret should be at least 64 characters long"
-	}
 
 	if len(errorList) != 0 {
 		return "", nil, errorList, nil

--- a/server/flow.go
+++ b/server/flow.go
@@ -509,8 +509,8 @@ func (fm *FlowManager) submitOAuthConfig(f *flow.Flow, submitted map[string]inte
 
 	clientID = strings.TrimSpace(clientID)
 
-	if len(clientID) != 64 {
-		errorList["client_id"] = "Client ID should be 64 characters long"
+	if len(clientID) < 64 {
+		errorList["client_id"] = "Client ID should be at least 64 characters long"
 	}
 
 	clientSecretRaw, ok := submitted["client_secret"]
@@ -524,8 +524,8 @@ func (fm *FlowManager) submitOAuthConfig(f *flow.Flow, submitted map[string]inte
 
 	clientSecret = strings.TrimSpace(clientSecret)
 
-	if len(clientSecret) != 64 {
-		errorList["client_secret"] = "Client Secret should be 64 characters long"
+	if len(clientSecret) < 64 {
+		errorList["client_secret"] = "Client Secret should be at least 64 characters long"
 	}
 
 	if len(errorList) != 0 {


### PR DESCRIPTION
#### Summary

According to https://github.com/mattermost/mattermost-plugin-gitlab/issues/412, GitLab is now providing client secrets greater than 64 characters. This PR makes it so we don't check the length anymore. The requirements in the external system could change at any point, so we should probably leave that validation out of our system.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/412
