### PR TITLE
[MM-99] Added a note to create subscription for "pipeline" event after running a pipeline

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -727,6 +727,7 @@ func (p *Plugin) pipelineRunCommand(ctx context.Context, namespace, ref, channel
 	if err != nil {
 		return err.Error()
 	}
+
 	var txt string
 	if pipelineInfo == nil {
 		txt = "Currently there is no pipeline info"
@@ -738,6 +739,25 @@ func (p *Plugin) pipelineRunCommand(ctx context.Context, namespace, ref, channel
 	txt += fmt.Sprintf("**Ref**: %s\n", pipelineInfo.Ref)
 	txt += fmt.Sprintf("**Triggered By**: %s\n", pipelineInfo.User)
 	txt += fmt.Sprintf("**Visit pipeline [here](%s)** \n\n", pipelineInfo.WebURL)
+
+	foundPipelineSubscription := false
+	subs, err := p.GetSubscriptionsByChannel(channelID)
+	if err != nil {
+		p.API.LogWarn("Failed to get subscriptions for the channel", "ChannelID", channelID, "Error", err.Error())
+		return txt
+	}
+
+	for _, sub := range subs {
+		if sub.Repository == namespace && sub.Pipeline() {
+			foundPipelineSubscription = true
+			break
+		}
+	}
+
+	if !foundPipelineSubscription {
+		txt += fmt.Sprintf("\n\n**Note:** This channel is currently not subscribed to pipeline event for `%s`. Run the command below if would you like to create a subscription.\n\n`/gitlab subscriptions add %s pipeline`", namespace, namespace)
+	}
+
 	return txt
 }
 

--- a/server/command.go
+++ b/server/command.go
@@ -743,7 +743,7 @@ func (p *Plugin) pipelineRunCommand(ctx context.Context, namespace, ref, channel
 	foundPipelineSubscription := false
 	subs, err := p.GetSubscriptionsByChannel(channelID)
 	if err != nil {
-		p.API.LogWarn("Failed to get subscriptions for the channel", "ChannelID", channelID, "Error", err.Error())
+		p.client.Log.Warn("Failed to get subscriptions for the channel", "channel_id", channelID, "error", err.Error())
 		return txt
 	}
 


### PR DESCRIPTION
#### Summary
Added a note to create subscription for "pipeline" event after running a pipeline

#### Screenshot:
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/55234496/f8db5f52-80f4-4438-95a0-7229d1f04259)

#### What to test?
- Getting a note to create a subscription for pipeline event if not present already.

#### Steps to reproduce:
1. Connect your GitLab account.
2. Run the pipeline of the desired project using the command below.
`/gitlab pipelines run <org/repo>  <branch-name>`
3. Make sure there was no subscription present for the project mentioned in the above command.

#### Ticket Link
Fixes #341 
