### PR TITLE
Added check for the 'show' prop before making API request for the link tooltip.

### DIFF
--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -118,7 +118,7 @@ export const LinkTooltip = ({href, connected, gitlabURL, show}) => {
         );
     };
 
-    if (!data) {
+    if (!data || !show) {
         return null;
     }
 

--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -42,7 +42,7 @@ export const getInfoAboutLink = (href, hostname) => {
     return {};
 };
 
-export const LinkTooltip = ({href, connected, gitlabURL}) => {
+export const LinkTooltip = ({href, connected, gitlabURL, show}) => {
     const [data, setData] = useState(null);
     const dispatch = useDispatch();
     useEffect(() => {
@@ -74,12 +74,12 @@ export const LinkTooltip = ({href, connected, gitlabURL}) => {
             }
         };
 
-        if (!connected) {
+        if (!connected || !show) {
             return;
         }
 
         init();
-    }, [connected, href]);
+    }, [connected, href, show]);
 
     const getIconElement = () => {
         const iconProps = {

--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -46,6 +46,10 @@ export const LinkTooltip = ({href, connected, gitlabURL, show}) => {
     const [data, setData] = useState(null);
     const dispatch = useDispatch();
     useEffect(() => {
+        if (!connected || !show) {
+            return;
+        }
+
         if (!isValidUrl(href)) {
             return;
         }
@@ -73,10 +77,6 @@ export const LinkTooltip = ({href, connected, gitlabURL, show}) => {
                 }
             }
         };
-
-        if (!connected || !show) {
-            return;
-        }
 
         init();
     }, [connected, href, show]);

--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -210,4 +210,5 @@ LinkTooltip.propTypes = {
     href: PropTypes.string.isRequired,
     connected: PropTypes.bool.isRequired,
     gitlabURL: PropTypes.string.isRequired,
+    show: PropTypes.bool,
 };


### PR DESCRIPTION
#### Summary
- Added check for the 'show' prop before making API request for the link tooltip.
- Added check if the data is already present for the link, do not make new API requests.

#### What to test?
- API request to fetch the data is sent when we hover over a Gitlab issue/PR link.
- API request is not sent if we have already made a request in the past and have not refreshed the page after that.

###### Steps to test:
1. Connect your Gitlab account.
2. Open the network tab of your browser.
3. Hover over a Gitlab issue/PR link.

#### Ticket Link
Fixes: https://community.mattermost.com/core/pl/zao9gnwgjpf6mmeo9y9xu8kngy

