### PR TITLE
[MM-283] Fix lint error

### DIFF
--- a/server/command_test.go
+++ b/server/command_test.go
@@ -252,7 +252,7 @@ func TestListWebhookCommand(t *testing.T) {
 func getTestPlugin(t *testing.T, mockCtrl *gomock.Controller, hooks []*gitlab.WebhookInfo, mattermostURL string, projectHookErr error, getProjectErr error, mockGitlab, noAccess bool) *Plugin {
 	p := new(Plugin)
 
-	accessLevel := gitLabAPI.OwnerPermission
+	accessLevel := gitLabAPI.OwnerPermissions
 	if noAccess {
 		accessLevel = gitLabAPI.GuestPermissions
 	}


### PR DESCRIPTION
#### Summary
- Error: SA1019: gitLabAPI.OwnerPermission is deprecated: Renamed to OwnerPermissions. (staticcheck)

#### Ticket Link
FIxes: https://github.com/mattermost/mattermost-plugin-gitlab/commit/54a9c4654f1400358051db9aa326cf6c684494f2#r139610896
