### PR TITLE
[MM-326] Fix issue of gitlab sidebar icons visible when user is not connected

### DIFF
--- a/webapp/src/components/sidebar_header/index.js
+++ b/webapp/src/components/sidebar_header/index.js
@@ -1,7 +1,8 @@
 import {connect} from 'react-redux';
 
-import SidebarHeader from './sidebar_header.jsx';
 import manifest from '../../manifest';
+
+import SidebarHeader from './sidebar_header.jsx';
 
 function mapStateToProps(state) {
     const members = state.entities.teams.myMembers || {};

--- a/webapp/src/components/sidebar_header/index.js
+++ b/webapp/src/components/sidebar_header/index.js
@@ -1,11 +1,13 @@
 import {connect} from 'react-redux';
 
 import SidebarHeader from './sidebar_header.jsx';
+import manifest from '../../manifest';
 
 function mapStateToProps(state) {
     const members = state.entities.teams.myMembers || {};
     return {
         show: Object.keys(members).length <= 1,
+        connected: state[`plugins-${manifest.id}`].connected,
     };
 }
 

--- a/webapp/src/components/sidebar_header/sidebar_header.jsx
+++ b/webapp/src/components/sidebar_header/sidebar_header.jsx
@@ -6,11 +6,12 @@ import SidebarButtons from '../sidebar_buttons';
 export default class SidebarHeader extends React.PureComponent {
     static propTypes = {
         show: PropTypes.bool.isRequired,
+        connected: PropTypes.bool.isRequired,
         theme: PropTypes.object.isRequired,
     };
 
     render() {
-        if (!this.props.show) {
+        if (!this.props.show || !this.props.connected) {
             return null;
         }
 


### PR DESCRIPTION
#### Summary
- Hide/unhide the LHS icons on the basis of user connection with GitLab

[screen-capture.webm](https://github.com/mattermost/mattermost-plugin-gitlab/assets/100013900/38cc3889-694d-4591-9eb4-33d3de466057)

#### Ticket Link
#467 

### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks
