### PR TITLE
[MM-402] Remove react-markdown package and use functions exposed by mattermost webapp

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -18,7 +18,6 @@
                 "react-bootstrap": "1.3.0",
                 "react-custom-scrollbars": "4.2.1",
                 "react-dom": "16.13.1",
-                "react-markdown": "^4.3.1",
                 "react-redux": "7.2.1",
                 "redux": "4.0.5",
                 "reselect": "4.1.6"
@@ -6001,15 +6000,6 @@
             "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
             "hasInstallScript": true
         },
-        "node_modules/bail": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6635,33 +6625,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/character-entities": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/character-entities-legacy": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/character-reference-invalid": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/cheerio": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -7070,15 +7033,6 @@
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
-            }
-        },
-        "node_modules/collapse-white-space": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-            "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/collect-v8-coverage": {
@@ -7926,6 +7880,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -7949,6 +7904,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7980,6 +7936,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.3.0"
             },
@@ -7994,6 +7951,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
             "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "dev": true,
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
@@ -8129,6 +8087,7 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
             "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -9256,11 +9215,6 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "node_modules/extend-shallow": {
             "version": "3.0.2",
@@ -10408,34 +10362,6 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
         },
-        "node_modules/html-to-react": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
-            "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
-            "dependencies": {
-                "domhandler": "^5.0",
-                "htmlparser2": "^8.0",
-                "lodash.camelcase": "^4.3.0"
-            }
-        },
-        "node_modules/html-to-react/node_modules/htmlparser2": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.0.1",
-                "entities": "^4.4.0"
-            }
-        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -10727,28 +10653,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-alphabetical": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/is-alphanumerical": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-            "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-            "dependencies": {
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-array-buffer": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -10904,15 +10808,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-decimal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -11002,15 +10897,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-hexadecimal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-interactive": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -11065,14 +10951,6 @@
             "dependencies": {
                 "is-buffer": "^1.1.5"
             },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-plain-obj": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11213,30 +11091,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-whitespace-character": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-            "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-word-character": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-            "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-wsl": {
@@ -13061,11 +12921,6 @@
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
             "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
-        "node_modules/lodash.camelcase": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
-        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -13300,15 +13155,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/markdown-escapes": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-            "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/marky": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
@@ -13362,14 +13208,6 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
-            }
-        },
-        "node_modules/mdast-add-list-metadata": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
-            "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
-            "dependencies": {
-                "unist-util-visit-parents": "1.1.2"
             }
         },
         "node_modules/memoize-one": {
@@ -15387,19 +15225,6 @@
                 }
             ]
         },
-        "node_modules/parse-entities": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-            "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-            "dependencies": {
-                "character-entities": "^1.0.0",
-                "character-entities-legacy": "^1.0.0",
-                "character-reference-invalid": "^1.0.0",
-                "is-alphanumerical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-hexadecimal": "^1.0.0"
-            }
-        },
         "node_modules/parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -16123,24 +15948,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
             "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-        },
-        "node_modules/react-markdown": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.3.1.tgz",
-            "integrity": "sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==",
-            "dependencies": {
-                "html-to-react": "^1.3.4",
-                "mdast-add-list-metadata": "1.0.1",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.6",
-                "remark-parse": "^5.0.0",
-                "unified": "^6.1.5",
-                "unist-util-visit": "^1.3.0",
-                "xtend": "^4.0.1"
-            },
-            "peerDependencies": {
-                "react": "^15.0.0 || ^16.0.0"
-            }
         },
         "node_modules/react-native": {
             "version": "0.73.6",
@@ -17040,28 +16847,6 @@
                 "jsesc": "bin/jsesc"
             }
         },
-        "node_modules/remark-parse": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-            "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-            "dependencies": {
-                "collapse-white-space": "^1.0.2",
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-whitespace-character": "^1.0.0",
-                "is-word-character": "^1.0.0",
-                "markdown-escapes": "^1.0.0",
-                "parse-entities": "^1.1.0",
-                "repeat-string": "^1.5.4",
-                "state-toggle": "^1.0.0",
-                "trim": "0.0.1",
-                "trim-trailing-lines": "^1.0.0",
-                "unherit": "^1.0.4",
-                "unist-util-remove-position": "^1.0.0",
-                "vfile-location": "^2.0.0",
-                "xtend": "^4.0.1"
-            }
-        },
         "node_modules/remote-redux-devtools": {
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
@@ -17103,14 +16888,6 @@
             "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
             "engines": {
                 "node": ">=0.10"
-            }
-        },
-        "node_modules/replace-ext": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-            "integrity": "sha512-vuNYXC7gG7IeVNBC1xUllqCcZKRbJoSPOBhnTEcAIiKCsbuef6zO3F0Rve3isPMMoNoQRWjQwbAgAjHUHniyEA==",
-            "engines": {
-                "node": ">= 0.10"
             }
         },
         "node_modules/require-directory": {
@@ -18066,15 +17843,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/state-toggle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-            "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -19010,30 +18778,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/trim": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-            "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
-            "deprecated": "Use String.prototype.trim() instead"
-        },
-        "node_modules/trim-trailing-lines": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
-            "integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/trough": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -19214,19 +18958,6 @@
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
             "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         },
-        "node_modules/unherit": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-            "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-            "dependencies": {
-                "inherits": "^2.0.0",
-                "xtend": "^4.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -19263,19 +18994,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/unified": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-            "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
-            "dependencies": {
-                "bail": "^1.0.0",
-                "extend": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
-                "trough": "^1.0.0",
-                "vfile": "^2.0.0",
-                "x-is-string": "^0.1.0"
-            }
-        },
         "node_modules/union-value": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -19306,49 +19024,6 @@
             "dev": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4"
-            }
-        },
-        "node_modules/unist-util-is": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-            "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "node_modules/unist-util-remove-position": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-            "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-            "dependencies": {
-                "unist-util-visit": "^1.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-stringify-position": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
-        },
-        "node_modules/unist-util-visit": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-            "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-            "dependencies": {
-                "unist-util-visit-parents": "^2.0.0"
-            }
-        },
-        "node_modules/unist-util-visit-parents": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
-            "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
-        },
-        "node_modules/unist-util-visit/node_modules/unist-util-visit-parents": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-            "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-            "dependencies": {
-                "unist-util-is": "^3.0.0"
             }
         },
         "node_modules/universalify": {
@@ -19581,34 +19256,6 @@
             "peer": true,
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/vfile": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-            "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-            "dependencies": {
-                "is-buffer": "^1.1.4",
-                "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "^1.0.0",
-                "vfile-message": "^1.0.0"
-            }
-        },
-        "node_modules/vfile-location": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-            "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/vfile-message": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-            "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-            "dependencies": {
-                "unist-util-stringify-position": "^1.1.1"
             }
         },
         "node_modules/vlq": {
@@ -20314,11 +19961,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/x-is-string": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-            "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
         },
         "node_modules/xml-name-validator": {
             "version": "3.0.0",
@@ -24940,11 +24582,6 @@
                 }
             }
         },
-        "bail": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
-        },
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -25415,21 +25052,6 @@
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
         },
-        "character-entities": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
-        },
-        "character-entities-legacy": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
-        },
-        "character-reference-invalid": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
-        },
         "cheerio": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -25738,11 +25360,6 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="
-        },
-        "collapse-white-space": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-            "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
         },
         "collect-v8-coverage": {
             "version": "1.0.1",
@@ -26442,6 +26059,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -26457,7 +26075,8 @@
         "domelementtype": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true
         },
         "domexception": {
             "version": "2.0.1",
@@ -26478,6 +26097,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.3.0"
             }
@@ -26486,6 +26106,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
             "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "dev": true,
             "requires": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
@@ -26601,7 +26222,8 @@
         "entities": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "dev": true
         },
         "envinfo": {
             "version": "7.11.1",
@@ -27480,11 +27102,6 @@
                     }
                 }
             }
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -28385,29 +28002,6 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
         },
-        "html-to-react": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
-            "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
-            "requires": {
-                "domhandler": "^5.0",
-                "htmlparser2": "^8.0",
-                "lodash.camelcase": "^4.3.0"
-            },
-            "dependencies": {
-                "htmlparser2": {
-                    "version": "8.0.2",
-                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-                    "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-                    "requires": {
-                        "domelementtype": "^2.3.0",
-                        "domhandler": "^5.0.3",
-                        "domutils": "^3.0.1",
-                        "entities": "^4.4.0"
-                    }
-                }
-            }
-        },
         "http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -28644,20 +28238,6 @@
                 }
             }
         },
-        "is-alphabetical": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
-        },
-        "is-alphanumerical": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-            "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-            "requires": {
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0"
-            }
-        },
         "is-array-buffer": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -28777,11 +28357,6 @@
                 "has-tostringtag": "^1.0.0"
             }
         },
-        "is-decimal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
-        },
         "is-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -28840,11 +28415,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-hexadecimal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
-        },
         "is-interactive": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -28883,11 +28453,6 @@
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
-        },
-        "is-plain-obj": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -28983,20 +28548,10 @@
                 "call-bind": "^1.0.2"
             }
         },
-        "is-whitespace-character": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-            "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
-        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-        },
-        "is-word-character": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-            "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
         },
         "is-wsl": {
             "version": "1.1.0",
@@ -30406,11 +29961,6 @@
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
             "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
-        "lodash.camelcase": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
-        },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -30596,11 +30146,6 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "markdown-escapes": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-            "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
-        },
         "marky": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
@@ -30650,14 +30195,6 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
-            }
-        },
-        "mdast-add-list-metadata": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
-            "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
-            "requires": {
-                "unist-util-visit-parents": "1.1.2"
             }
         },
         "memoize-one": {
@@ -32244,19 +31781,6 @@
                 }
             }
         },
-        "parse-entities": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-            "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-            "requires": {
-                "character-entities": "^1.0.0",
-                "character-entities-legacy": "^1.0.0",
-                "character-reference-invalid": "^1.0.0",
-                "is-alphanumerical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-hexadecimal": "^1.0.0"
-            }
-        },
         "parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -32846,21 +32370,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
             "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-        },
-        "react-markdown": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.3.1.tgz",
-            "integrity": "sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==",
-            "requires": {
-                "html-to-react": "^1.3.4",
-                "mdast-add-list-metadata": "1.0.1",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.6",
-                "remark-parse": "^5.0.0",
-                "unified": "^6.1.5",
-                "unist-util-visit": "^1.3.0",
-                "xtend": "^4.0.1"
-            }
         },
         "react-native": {
             "version": "0.73.6",
@@ -33587,28 +33096,6 @@
                 }
             }
         },
-        "remark-parse": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-            "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-            "requires": {
-                "collapse-white-space": "^1.0.2",
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-whitespace-character": "^1.0.0",
-                "is-word-character": "^1.0.0",
-                "markdown-escapes": "^1.0.0",
-                "parse-entities": "^1.1.0",
-                "repeat-string": "^1.5.4",
-                "state-toggle": "^1.0.0",
-                "trim": "0.0.1",
-                "trim-trailing-lines": "^1.0.0",
-                "unherit": "^1.0.4",
-                "unist-util-remove-position": "^1.0.0",
-                "vfile-location": "^2.0.0",
-                "xtend": "^4.0.1"
-            }
-        },
         "remote-redux-devtools": {
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
@@ -33644,11 +33131,6 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
-        },
-        "replace-ext": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-            "integrity": "sha512-vuNYXC7gG7IeVNBC1xUllqCcZKRbJoSPOBhnTEcAIiKCsbuef6zO3F0Rve3isPMMoNoQRWjQwbAgAjHUHniyEA=="
         },
         "require-directory": {
             "version": "2.1.1",
@@ -34427,11 +33909,6 @@
                 }
             }
         },
-        "state-toggle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-            "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
-        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -35162,21 +34639,6 @@
                 "punycode": "^2.1.1"
             }
         },
-        "trim": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-            "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="
-        },
-        "trim-trailing-lines": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
-            "integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ=="
-        },
-        "trough": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
-        },
         "tsconfig-paths": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -35326,15 +34788,6 @@
                 }
             }
         },
-        "unherit": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-            "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-            "requires": {
-                "inherits": "^2.0.0",
-                "xtend": "^4.0.0"
-            }
-        },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -35358,19 +34811,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
             "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ=="
-        },
-        "unified": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-            "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
-            "requires": {
-                "bail": "^1.0.0",
-                "extend": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
-                "trough": "^1.0.0",
-                "vfile": "^2.0.0",
-                "x-is-string": "^0.1.0"
-            }
         },
         "union-value": {
             "version": "1.0.1",
@@ -35400,47 +34840,6 @@
             "requires": {
                 "imurmurhash": "^0.1.4"
             }
-        },
-        "unist-util-is": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-            "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "unist-util-remove-position": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-            "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-            "requires": {
-                "unist-util-visit": "^1.1.0"
-            }
-        },
-        "unist-util-stringify-position": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
-        },
-        "unist-util-visit": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-            "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-            "requires": {
-                "unist-util-visit-parents": "^2.0.0"
-            },
-            "dependencies": {
-                "unist-util-visit-parents": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-                    "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-                    "requires": {
-                        "unist-util-is": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "unist-util-visit-parents": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
-            "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
         },
         "universalify": {
             "version": "0.2.0",
@@ -35621,30 +35020,6 @@
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "peer": true
-        },
-        "vfile": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-            "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-            "requires": {
-                "is-buffer": "^1.1.4",
-                "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "^1.0.0",
-                "vfile-message": "^1.0.0"
-            }
-        },
-        "vfile-location": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-            "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
-        },
-        "vfile-message": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-            "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-            "requires": {
-                "unist-util-stringify-position": "^1.1.1"
-            }
         },
         "vlq": {
             "version": "1.0.1",
@@ -36189,11 +35564,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
             "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
             "requires": {}
-        },
-        "x-is-string": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-            "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -26,7 +26,6 @@
         "react-bootstrap": "1.3.0",
         "react-custom-scrollbars": "4.2.1",
         "react-dom": "16.13.1",
-        "react-markdown": "^4.3.1",
         "react-redux": "7.2.1",
         "redux": "4.0.5",
         "reselect": "4.1.6"

--- a/webapp/src/components/link_tooltip/index.tsx
+++ b/webapp/src/components/link_tooltip/index.tsx
@@ -1,5 +1,4 @@
 import React, {useEffect, useState} from 'react';
-import ReactMarkdown from 'react-markdown';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {logError} from 'mattermost-redux/actions/errors';
@@ -122,6 +121,7 @@ const LinkTooltip = ({href, show}: Props) => {
     };
 
     const date = new Date(data.created_at).toDateString();
+    const {formatText, messageHtmlToComponent} = window.PostUtils;
 
     return (
         <div className='gitlab-tooltip'>
@@ -148,11 +148,7 @@ const LinkTooltip = ({href, show}: Props) => {
                             <span className='mr-number'>{`#${data.iid}`}</span>
                         </a>
                         <div className='markdown-text mt-1 mb-1'>
-                            <ReactMarkdown
-                                source={data.description}
-                                disallowedTypes={['heading']}
-                                linkTarget='_blank'
-                            />
+                            {messageHtmlToComponent(formatText(data.description), false)}
                         </div>
 
                         {data.type === LINK_TYPES.MERGE_REQUESTS && (

--- a/webapp/src/hooks/index.ts
+++ b/webapp/src/hooks/index.ts
@@ -7,8 +7,7 @@ import {isDesktopApp} from 'src/utils/user_agent';
 import {connectUsingBrowserMessage} from 'src/constants';
 
 import {sendEphemeralPost} from '../actions';
-
-type ContextArgs = {channel_id: string};
+import {ContextArgs} from '../types/mattermost-webapp';
 
 const connectCommand = '/gitlab connect';
 

--- a/webapp/src/index.ts
+++ b/webapp/src/index.ts
@@ -97,7 +97,7 @@ class PluginClass {
     }
 
     deinitialize() {
-        document.removeEventListener('click', activityFunc);
+        document.removeEventListener('click', activityFunc as EventListenerOrEventListenerObject);
     }
 }
 

--- a/webapp/src/index.ts
+++ b/webapp/src/index.ts
@@ -30,7 +30,7 @@ import Hooks from './hooks';
 
 import {FormatTextOptions, MessageHtmlToComponentOptions, PluginRegistry} from './types/mattermost-webapp';
 
-let activityFunc: () => void;
+let activityFunc: (() => void) | undefined;
 let lastActivityTime = Number.MAX_SAFE_INTEGER;
 const activityTimeout = 60 * 60 * 1000; // 1 hour
 const {id} = manifest;

--- a/webapp/src/index.ts
+++ b/webapp/src/index.ts
@@ -97,7 +97,9 @@ class PluginClass {
     }
 
     deinitialize() {
-        document.removeEventListener('click', activityFunc as EventListenerOrEventListenerObject);
+        if (activityFunc) {
+            document.removeEventListener('click', activityFunc);
+        }
     }
 }
 

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export type ContextArgs = {channel_id: string};
+
+type FormatTextOptions = {
+    atMentions?: boolean;
+    markdown?: boolean;
+}
+
+type MessageHtmlToComponentOptions = {
+    mentionHighlight: boolean;
+}
+
+export interface PluginRegistry {
+    registerReducer(reducer)
+    registerPostTypeComponent(typeName: string, component: React.ElementType)
+    registerRightHandSidebarComponent(component: React.ReactNode, title: string | JSX.Element)
+    registerSlashCommandWillBePostedHook(hook: (rawMessage: string, contextArgs: ContextArgs) => Promise<{}>)
+    registerWebSocketEventHandler(event: string, handler: (msg: any) => void)
+    registerAppBarComponent(iconUrl: string, action: () => void, tooltipText: string)
+    registerLeftSidebarHeaderComponent(component: React.ReactNode)
+    registerBottomTeamSidebarComponent(component: React.ReactNode)
+    registerPopoverUserAttributesComponent(component: React.ReactNode)
+    registerLinkTooltipComponent(component: React.ReactNode)
+    registerReconnectHandler(handler: any)
+
+    // Add more if needed from https://developers.mattermost.com/extend/plugins/webapp/reference
+}

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path');
 
 module.exports = {
     entry: [
-        './src/index.js',
+        './src/index.ts',
     ],
     resolve: {
         modules: [


### PR DESCRIPTION
#### Summary
- Removed react-markdown package and used functions exposed by mattermost webapp 
- Converted `index.js` file to `index.ts` present in root of webapp folder

#### Screenshot

##### Before
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/100013900/2b685243-e50b-45b6-9fac-721b3b766479)

##### After
![image](https://github.com/mattermost/mattermost-plugin-gitlab/assets/100013900/f018059d-a3f1-4a53-945a-bf52ca29c274)

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-gitlab/security/dependabot/11

#### What to test?
- Complete test of link tooltip feature

#### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks