### PR TITLE
Migrate setup/config/usage to Product Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Originally developed by [Romain Maneschi](https://github.com/manland). This proj
 
 **Co-Maintainer:** [@hanzei](https://github.com/hanzei)
 
+See the [Mattermost Product Documentation](https://docs.mattermost.com/integrate/integrate/gitlab-interoperability.html) for details on installing, configuring, enabling, and using this Mattermost integration.
+
 ## Feature summary of GitLab to Mattermost notifications
 
 ### Channel subscriptions
@@ -41,121 +43,6 @@ Each user in Mattermost is connected with their own personal GitLab account. Use
 ### Sidebar buttons
 
 Team members can stay up-to-date with how many reviews, todos, assigned issues, and assigned merge requests they have by using buttons in the Mattermost sidebar.
-
-## Admin guide
-  
-Get started by installing the GitLab plugin from the Marketplace.
-
-### Prerequisites
-
-* The GitLab plugin is included in the Plugin Marketplace in Mattermost v5.16 and above.
-* For Mattermost v5.13 and earlier, a manual install is necessary.
-
-## Installation
-  
-### Marketplace installation
-
-1. Go to **Main Menu > Plugin Marketplace** in Mattermost.
-2. Search for "gitlab" or manually find the plugin from the list and select **Install**.
-3. After the plugin has downloaded and been installed, select the **Configure** button.
-
-### Manual installation
-
-If your server doesn't have access to the internet, you can download the latest [plugin binary release](https://github.com/mattermost/mattermost-plugin-gitlab/releases) and upload it to your server via **System Console > Plugins > Plugin Management**. The releases on this page are the same used by the Marketplace. 
-
-See the [GitLab plugin release page](https://github.com/mattermost/mattermost-plugin-gitlab/releases) for compatibility considerations.
-
-## Configuration
-
-### Step 1: Register an OAuth application in GitLab
-
-1. Go to https://gitlab.com/-/profile/applications or https://gitlab.yourdomain.com/-/profile/applications to register an OAuth app.
-1. Set the following values:
-   - **Name**: `Mattermost GitLab Plugin - <your company name>`
-   - **Redirect URI**: `https://your-mattermost-url.com/plugins/com.github.manland.mattermost-plugin-gitlab/oauth/complete`, replacing `https://your-mattermost-url.com` with your Mattermost URL
-1. Select `api` and `read_user` in **Scopes**.
-1. Save the application. Copy the **Application ID** and **Secret** fields in the resulting screen.
-1. In Mattermost, go to **Plugins Marketplace > GitLab > Configure**, and enter the **GitLab URL**, **GitLab OAuth Client ID**, and **GitLab OAuth Client Secret**.
-
-### Step 2: Configure the plugin in Mattermost
-
-1. Go to **System Console > Plugins > GitLab** and do the following:
-    - Generate a new value for **Webhook Secret**.
-    - Generate a new value for **At Rest Encryption Key**.
-    - (Optional) **GitLab Group**: Lock the plugin to a single GitLab group by setting this field to the name of your GitLab group.
-    - (Optional) **Enable Private Repositories**: Allow the plugin to receive notifications from private repositories by setting this value to `true`. When enabled, existing users must reconnect their accounts to gain access to private project. Affected users will be notified by the plugin once private repositories are enabled.
-1. Select **Save**.
-1. Go to **Plugins Marketplace > GitLab > Configure > Enable Plugin** and select **Enable** to enable the GitLab plugin.
-
-### Step 3: Connect your GitLab accounts
-
-Run the `/gitlab connect` slash command to connect your Mattermost account with GitLab.
-
-### Step 4: Subscribe to projects and groups
-
-For each project you want to receive notifications for or subscribe to, you must create a webhook. Run the subscribe slash command to watch events sent from GitLab.
-
-``/gitlab subscriptions add group[/project]``
-
-Run the webhook slash command to have GitLab send events to Mattermost. 
-
-``/gitlab webhook add group[/project]``
-
-For versions prior to 1.2: 
-
-1. In GitLab, go to the project you want to subscribe to, select **Settings > Integrations** in the sidebar.
-2. Set the following values:
-   - **URL**: `https://your-mattermost-url.com/plugins/com.github.manland.mattermost-plugin-gitlab/webhook`, replacing `https://your-mattermost-url.com` with your Mattermost URL. Ensure that you add `/plugins/com.github.manland.mattermost-plugin-gitlab/webhook` to the URL or the webhook won't work.
-   - **Secret Token**: The webhook secret you copied previously.
-3. Select all the events in **Triggers**.
-4. Add the webhook.
-
-### Compatibility
-
-| Mattermost-Plugin-Gitlab| Mattermost | GitLab |
-|:-----------------------:|:----------:|:------:|
-|        0.3.0            |     5.10+  |  11.2+ |
-|        0.2.0            |     5.8+   |  11.2+ |
-|        0.1.0            |     5.8+   |  11.2+ |
-
-### Update the plugin
-
-When a new version of the plugin is released to the **Plugin Marketplace**, the system will display a prompt asking you to update your current version of the GitLab plugin to the newest one. There may be a warning shown if there is a major version change that **may** affect the installation. Generally, updates are seamless and don't interrupt the user experience in Mattermost.
-  
-## Mattermost commands user guide
-
-Interact with the GitLab plugin using the `/gitlab` slash command.
-
-### Subscribe to/unsubscribe from a repository
-
-Use `/gitlab subscriptions add owner[/repo] [features]` to subscribe a Mattermost channel to receive posts for new merge requests and/or issues, or other features (as listed above), from a GitLab repository. Ensure that the webhook is configured, otherwise this will not work properly.
-
-Use `/gitlab subscriptions delete owner/repo` to unsubscribe from it.  
-
-`/gitlab subscriptions list` lists what you have subscribed to.
-
-### Connect to/disconnect from GitLab
-
-Connect your Mattermost account to your GitLab account using `/gitlab connect` and disconnect it using`/gitlab disconnect`. 
-
-`/gitlab me` displays the connected GitLab account.
-
-### Get "To Do" items
-
-Use `/gitlab todo` to get a list of todos, assigned issues, assigned merge requests and merge requests awaiting your review.
-
-### Update settings
-
-Use `/gitlab settings [setting] [value]` to update your settings for the plugin.  There are two settings:
-
-- To turn **personal notifications** `on` or `off`.
-- To turn **reminders** `on` or `off` for when you connect for the first time each day.  
-
-### And more...
-
-Run `/gitlab help` to see what else the slash command can do.
-
-**Tip**: Don't forget to add a webhook in GitLab!
 
 ## Development
   


### PR DESCRIPTION
Install, setup, configure, and usage content migration is part of a [larger docs consolidation effort](https://github.com/mattermost/docs/pull/7030) across all Mattermost-supported plugins.