### PR TITLE
[GH-449] Fix DM notification messages

### DIFF
--- a/server/webhook/merge_request.go
+++ b/server/webhook/merge_request.go
@@ -34,14 +34,14 @@ func (w *webhook) handleDMMergeRequest(event *gitlab.MergeEvent) ([]*HandleWebho
 	case stateOpened:
 		switch event.ObjectAttributes.Action {
 		case actionOpen:
-			message = fmt.Sprintf("[%s](%s) requested your review on [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+			message = fmt.Sprintf("[%s](%s) requested your review on [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 			handlers = []*HandleWebhook{{
 				Message: message,
 				ToUsers: toUsers,
 				From:    senderGitlabUsername,
 			}}
 		case actionReopen:
-			message = fmt.Sprintf("[%s](%s) reopened your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+			message = fmt.Sprintf("[%s](%s) reopened your merge request [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 			handlers = []*HandleWebhook{{
 				Message: message,
 				ToUsers: toUsers,
@@ -58,7 +58,7 @@ func (w *webhook) handleDMMergeRequest(event *gitlab.MergeEvent) ([]*HandleWebho
 				updatedCurrentUsers := w.calculateUserDiffs(event.Changes.Assignees.Previous, event.Changes.Assignees.Current)
 
 				if len(updatedCurrentUsers) != 0 {
-					message = fmt.Sprintf("[%s](%s) assigned you to merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+					message = fmt.Sprintf("[%s](%s) assigned you to merge request [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 					handlers = append(handlers, &HandleWebhook{
 						Message: message,
 						ToUsers: updatedCurrentUsers,
@@ -72,7 +72,7 @@ func (w *webhook) handleDMMergeRequest(event *gitlab.MergeEvent) ([]*HandleWebho
 				updatedCurrentUsers := w.calculateUserDiffs(event.Changes.Reviewers.Previous, event.Changes.Reviewers.Current)
 
 				if len(updatedCurrentUsers) != 0 {
-					message = fmt.Sprintf("[%s](%s) requested your review on merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+					message = fmt.Sprintf("[%s](%s) requested your review on merge request [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 					handlers = append(handlers, &HandleWebhook{
 						Message: message,
 						ToUsers: updatedCurrentUsers,
@@ -81,14 +81,14 @@ func (w *webhook) handleDMMergeRequest(event *gitlab.MergeEvent) ([]*HandleWebho
 				}
 			}
 		case actionApproved:
-			message = fmt.Sprintf("[%s](%s) approved your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+			message = fmt.Sprintf("[%s](%s) approved your merge request [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 			handlers = []*HandleWebhook{{
 				Message: message,
 				ToUsers: toUsers,
 				From:    senderGitlabUsername,
 			}}
 		case actionUnapproved:
-			message = fmt.Sprintf("[%s](%s) requested changes to your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+			message = fmt.Sprintf("[%s](%s) requested changes to your merge request [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 			handlers = []*HandleWebhook{{
 				Message: message,
 				ToUsers: toUsers,
@@ -96,7 +96,7 @@ func (w *webhook) handleDMMergeRequest(event *gitlab.MergeEvent) ([]*HandleWebho
 			}}
 		}
 	case stateClosed:
-		message = fmt.Sprintf("[%s](%s) closed your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+		message = fmt.Sprintf("[%s](%s) closed your merge request [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 		handlers = []*HandleWebhook{{
 			Message: message,
 			ToUsers: toUsers,
@@ -104,7 +104,7 @@ func (w *webhook) handleDMMergeRequest(event *gitlab.MergeEvent) ([]*HandleWebho
 		}}
 	case stateMerged:
 		if event.ObjectAttributes.Action == actionMerge {
-			message = fmt.Sprintf("[%s](%s) merged your merge request [%s!%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.Target.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+			message = fmt.Sprintf("[%s](%s) merged your merge request [#%d](%s) in [%s](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.ObjectAttributes.IID, event.ObjectAttributes.URL, event.ObjectAttributes.Target.PathWithNamespace, event.Repository.Homepage)
 			handlers = []*HandleWebhook{{
 				Message: message,
 				ToUsers: toUsers,

--- a/server/webhook/merge_request_test.go
+++ b/server/webhook/merge_request_test.go
@@ -27,7 +27,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[root](http://my.gitlab.com/root) requested your review on [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{"manland"},
 			ToChannels: []string{},
 			From:       "root",
@@ -44,7 +44,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/subgroup/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/subgroup/webhook!4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4)",
+			Message:    "[root](http://my.gitlab.com/root) requested your review on [#4](http://localhost:3000/manland/subgroup/webhook/merge_requests/4) in [manland/subgroup/webhook](http://localhost:3000/manland/subgroup/webhook)",
 			ToUsers:    []string{"manland"},
 			ToChannels: []string{},
 			From:       "root",
@@ -61,7 +61,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) closed your merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[manland](http://my.gitlab.com/manland) closed your merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
@@ -78,7 +78,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) reopened your merge request [manland/webhook!1](http://localhost:3000/manland/webhook/merge_requests/1)",
+			Message:    "[manland](http://my.gitlab.com/manland) reopened your merge request [#1](http://localhost:3000/manland/webhook/merge_requests/1) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
@@ -94,7 +94,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{}),
 		res: []*HandleWebhook{
 			{
-				Message:    "[root](http://my.gitlab.com/root) assigned you to merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+				Message:    "[root](http://my.gitlab.com/root) assigned you to merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 				ToUsers:    []string{"manland"},
 				ToChannels: []string{},
 				From:       "root",
@@ -106,7 +106,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{}),
 		res: []*HandleWebhook{
 			{
-				Message:    "[root](http://my.gitlab.com/root) requested your review on merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+				Message:    "[root](http://my.gitlab.com/root) requested your review on merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 				ToUsers:    []string{"manland"},
 				ToChannels: []string{},
 				From:       "root",
@@ -118,7 +118,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{}),
 		res: []*HandleWebhook{
 			{
-				Message:    "[user](http://my.gitlab.com/user) assigned you to merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+				Message:    "[user](http://my.gitlab.com/user) assigned you to merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 				ToUsers:    []string{"manland"},
 				ToChannels: []string{},
 				From:       "user",
@@ -130,7 +130,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{}),
 		res: []*HandleWebhook{
 			{
-				Message:    "[user](http://my.gitlab.com/user) assigned you to merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+				Message:    "[user](http://my.gitlab.com/user) assigned you to merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 				ToUsers:    []string{},
 				ToChannels: []string{},
 				From:       "user",
@@ -143,7 +143,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) merged your merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[manland](http://my.gitlab.com/manland) merged your merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
@@ -160,7 +160,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) approved your merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[manland](http://my.gitlab.com/manland) approved your merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
@@ -177,7 +177,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[manland](http://my.gitlab.com/manland) requested changes to your merge request [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[manland](http://my.gitlab.com/manland) requested changes to your merge request [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{"root"},
 			ToChannels: []string{},
 			From:       "manland",
@@ -194,7 +194,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) closed your merge request [manland/webhook!1](http://localhost:3000/manland/webhook/merge_requests/1)",
+			Message:    "[root](http://my.gitlab.com/root) closed your merge request [#1](http://localhost:3000/manland/webhook/merge_requests/1) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{}, // no assignee
 			ToChannels: []string{},
 			From:       "root",
@@ -211,7 +211,7 @@ var testDataMergeRequest = []testDataMergeRequestStr{
 			{ChannelID: "channel1", CreatorID: "1", Features: "issues", Repository: "manland/webhook"},
 		}),
 		res: []*HandleWebhook{{
-			Message:    "[root](http://my.gitlab.com/root) requested your review on [manland/webhook!4](http://localhost:3000/manland/webhook/merge_requests/4)",
+			Message:    "[root](http://my.gitlab.com/root) requested your review on [#4](http://localhost:3000/manland/webhook/merge_requests/4) in [manland/webhook](http://localhost:3000/manland/webhook)",
 			ToUsers:    []string{"manland"},
 			ToChannels: []string{},
 			From:       "root",


### PR DESCRIPTION
#### Summary
- Fix DM notification messages
- Earlier the merge request number was getting blended inside the repo name

#### Screenshot:
Earlier:
![image](https://github.com/user-attachments/assets/7e2de403-78c0-42e8-85e4-73e9c73d7d74)

Now:
![image](https://github.com/user-attachments/assets/7a6c9815-1289-4400-97f7-fb862f05b4ac)

#### What to test:
- Getting proper DM notifications for events on Gitlab

#### How to test:
- Connect you Gitlab account.
- Setup webhook
- Trigger the desired event from GItlab.

#### Ticket Link
Fixes #449 

