### PR TITLE
[MM-387]: Added support to subscribe to release and deployment

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -34,6 +34,8 @@ const commandHelp = `* |/gitlab connect| - Connect your Mattermost account to yo
 	* tag - include tag creation
     * pull_reviews - includes merge request reviews
 	* label:"<labelname>" - must include "merges" or "issues" in feature list when using a label
+	* deployments - includes deployments
+	* releases - includes releases
     * Defaults to "merges,issues,tag"
 * |/gitlab subscriptions delete owner/repo| - Unsubscribe the current channel from a repository
 * |/gitlab pipelines run [owner]/repo [ref]| - Run a pipeline for specific repository and ref (branch/tag)
@@ -56,6 +58,8 @@ const commandHelp = `* |/gitlab connect| - Connect your Mattermost account to yo
 	 * JobEvents 
 	 * PipelineEvents 
 	 * WikiPageEvents
+	 * DeploymentEvents
+	 * RelaseEvents
 	 * SSLverification
   * |url| is the URL that will be called when triggered. Defaults to this plugins URL
   * |token| Secret token. Defaults to secret token used in plugin's settings.
@@ -493,7 +497,7 @@ func (p *Plugin) webhookCommand(ctx context.Context, parameters []string, info *
 
 func parseTriggers(triggersCsv string) *gitlab.AddWebhookOptions {
 	var sslVerification, pushEvents, tagPushEvents, issuesEvents, confidentialIssuesEvents, noteEvents bool
-	var confidentialNoteEvents, mergeRequestsEvents, jobEvents, pipelineEvents, wikiPageEvents bool
+	var confidentialNoteEvents, mergeRequestsEvents, jobEvents, pipelineEvents, wikiPageEvents, deploymentEvents, releaseEvents bool
 	var all bool
 	if triggersCsv == "*" {
 		all = true
@@ -538,6 +542,12 @@ func parseTriggers(triggersCsv string) *gitlab.AddWebhookOptions {
 		if all || strings.EqualFold(trigger, "WikiPageEvents") {
 			wikiPageEvents = true
 		}
+		if all || strings.EqualFold(trigger, "DeploymentEvents") {
+			deploymentEvents = true
+		}
+		if all || strings.EqualFold(trigger, "releaseEvents") {
+			releaseEvents = true
+		}
 	}
 
 	return &gitlab.AddWebhookOptions{
@@ -552,6 +562,8 @@ func parseTriggers(triggersCsv string) *gitlab.AddWebhookOptions {
 		JobEvents:                jobEvents,
 		PipelineEvents:           pipelineEvents,
 		WikiPageEvents:           wikiPageEvents,
+		DeploymentEvents:         deploymentEvents,
+		ReleaseEvents:            releaseEvents,
 	}
 }
 
@@ -815,7 +827,7 @@ func getAutocompleteData(config *configuration) *model.AutocompleteData {
 
 	subscriptionsAdd := model.NewAutocompleteData(commandAdd, "owner[/repo] [features]", "Subscribe the current channel to receive notifications from a project")
 	subscriptionsAdd.AddTextArgument("Project path: includes user or group name with optional slash project name", "owner[/repo]", "")
-	subscriptionsAdd.AddTextArgument("comma-delimited list of features to subscribe to: issues, confidential_issues, merges, pushes, issue_comments, merge_request_comments, pipeline, tag, pull_reviews, label:<labelName>", "[features] (optional)", `/[^,-\s]+(,[^,-\s]+)*/`)
+	subscriptionsAdd.AddTextArgument("comma-delimited list of features to subscribe to: issues, confidential_issues, merges, pushes, issue_comments, merge_request_comments, pipeline, tag, pull_reviews, label:<labelName>, deployments, releases", "[features] (optional)", `/[^,-\s]+(,[^,-\s]+)*/`)
 	subscriptions.AddCommand(subscriptionsAdd)
 
 	subscriptionsDelete := model.NewAutocompleteData(commandDelete, "owner[/repo]", "Unsubscribe the current channel from a repository")

--- a/server/flow.go
+++ b/server/flow.go
@@ -671,6 +671,8 @@ func (fm *FlowManager) submitWebhook(f *flow.Flow, submitted map[string]interfac
 		JobEvents:                true,
 		PipelineEvents:           true,
 		WikiPageEvents:           true,
+		DeploymentEvents:         true,
+		ReleaseEvents:            true,
 		EnableSSLVerification:    true,
 		Token:                    config.WebhookSecret,
 	}

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -74,6 +74,8 @@ func (g *gitlab) NewGroupHook(ctx context.Context, user *UserInfo, token *oauth2
 		JobEvents:                &webhookOptions.JobEvents,
 		PipelineEvents:           &webhookOptions.PipelineEvents,
 		WikiPageEvents:           &webhookOptions.WikiPageEvents,
+		DeploymentEvents:         &webhookOptions.DeploymentEvents,
+		ReleasesEvents:           &webhookOptions.ReleaseEvents,
 		EnableSSLVerification:    &webhookOptions.EnableSSLVerification,
 		Token:                    &webhookOptions.Token,
 	}
@@ -111,6 +113,8 @@ func (g *gitlab) NewProjectHook(ctx context.Context, user *UserInfo, token *oaut
 		JobEvents:                &webhookOptions.JobEvents,
 		PipelineEvents:           &webhookOptions.PipelineEvents,
 		WikiPageEvents:           &webhookOptions.WikiPageEvents,
+		DeploymentEvents:         &webhookOptions.DeploymentEvents,
+		ReleasesEvents:           &webhookOptions.ReleaseEvents,
 		EnableSSLVerification:    &webhookOptions.EnableSSLVerification,
 		Token:                    &webhookOptions.Token,
 	}
@@ -189,6 +193,12 @@ func (w *WebhookInfo) String() string {
 	if w.WikiPageEvents {
 		formatedTriggers += "* Wiki Page Events\n"
 	}
+	if w.ReleaseEvents {
+		formatedTriggers += "* Release Events\n"
+	}
+	if w.DeploymentEvents {
+		formatedTriggers += "* Deployment Events\n"
+	}
 
 	return "\n\n`" + w.URL + "`\n" + formatedTriggers
 }
@@ -208,6 +218,8 @@ func getProjectHookInfo(hook *internGitlab.ProjectHook) *WebhookInfo {
 		JobEvents:                hook.JobEvents,
 		PipelineEvents:           hook.PipelineEvents,
 		WikiPageEvents:           hook.WikiPageEvents,
+		DeploymentEvents:         hook.DeploymentEvents,
+		ReleaseEvents:            hook.ReleasesEvents,
 		EnableSSLVerification:    hook.EnableSSLVerification,
 		CreatedAt:                hook.CreatedAt,
 	}
@@ -229,6 +241,8 @@ func getGroupHookInfo(hook *internGitlab.GroupHook) *WebhookInfo {
 		JobEvents:                hook.JobEvents,
 		PipelineEvents:           hook.PipelineEvents,
 		WikiPageEvents:           hook.WikiPageEvents,
+		DeploymentEvents:         hook.DeploymentEvents,
+		ReleaseEvents:            hook.ReleasesEvents,
 		EnableSSLVerification:    hook.EnableSSLVerification,
 		CreatedAt:                hook.CreatedAt,
 	}

--- a/server/gitlab/webhook.go
+++ b/server/gitlab/webhook.go
@@ -18,6 +18,8 @@ type WebhookInfo struct {
 	JobEvents                bool
 	PipelineEvents           bool
 	WikiPageEvents           bool
+	DeploymentEvents         bool
+	ReleaseEvents            bool
 	EnableSSLVerification    bool
 	CreatedAt                *time.Time
 	Scope                    Scope
@@ -36,6 +38,8 @@ type AddWebhookOptions struct {
 	JobEvents                bool
 	PipelineEvents           bool
 	WikiPageEvents           bool
+	DeploymentEvents         bool
+	ReleaseEvents            bool
 	EnableSSLVerification    bool
 	Token                    string
 }

--- a/server/subscription/subscription.go
+++ b/server/subscription/subscription.go
@@ -17,6 +17,8 @@ var allFeatures = map[string]bool{
 	"tag":                    true,
 	"pull_reviews":           true,
 	"confidential_issues":    true,
+	"deployments":            true,
+	"releases":               true,
 	// "label:":                 true,//particular case for label:XXX
 }
 
@@ -97,4 +99,12 @@ func (s *Subscription) Label() string {
 		return ""
 	}
 	return strings.Split(s.Features, "\"")[1]
+}
+
+func (s *Subscription) Releases() bool {
+	return strings.Contains(s.Features, "releases")
+}
+
+func (s *Subscription) Deployments() bool {
+	return strings.Contains(s.Features, "deployments")
 }

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -135,6 +135,15 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		pathWithNamespace = event.Project.PathWithNamespace
 		fromUser = event.UserName
 		handlers, errHandler = p.WebhookHandler.HandleTag(ctx, event)
+	case *gitlabLib.ReleaseEvent:
+		repoPrivate = event.Project.VisibilityLevel == webhook.PrivateVisibilityLevel
+		pathWithNamespace = event.Project.PathWithNamespace
+		handlers, errHandler = p.WebhookHandler.HandleRelease(ctx, event)
+	case *gitlabLib.DeploymentEvent:
+		repoPrivate = event.Project.VisibilityLevel == webhook.PrivateVisibilityLevel
+		pathWithNamespace = event.Project.PathWithNamespace
+		fromUser = event.User.Username
+		handlers, errHandler = p.WebhookHandler.HandleDeployment(ctx, event)
 	default:
 		p.client.Log.Debug("Event type not implemented", "type", string(gitlabLib.WebhookEventType(r)))
 		return

--- a/server/webhook/constants.go
+++ b/server/webhook/constants.go
@@ -17,4 +17,12 @@ const (
 	statusRunning = "running"
 	statusPending = "pending"
 	statusFailed  = "failed"
+	statusCreated = "created"
+
+	statusCreate = "create"
+	statusUpdate = "update"
+	statusDelete = "delete"
+
+	PrivateVisibilityLevel = 0
+	PublicVisibilityLevel  = 20
 )

--- a/server/webhook/constants.go
+++ b/server/webhook/constants.go
@@ -13,11 +13,11 @@ const (
 	stateClosed = "closed"
 	stateMerged = "merged"
 
-	statusSuccess = "success"
-	statusRunning = "running"
-	statusPending = "pending"
-	statusFailed  = "failed"
-	statusCreated = "created"
+	statusSuccess  = "success"
+	statusRunning  = "running"
+	statusPending  = "pending"
+	statusFailed   = "failed"
+	statusCreated  = "created"
 	statusCanceled = "canceled"
 
 	statusCreate = "create"

--- a/server/webhook/constants.go
+++ b/server/webhook/constants.go
@@ -18,6 +18,7 @@ const (
 	statusPending = "pending"
 	statusFailed  = "failed"
 	statusCreated = "created"
+	statusCanceled = "canceled"
 
 	statusCreate = "create"
 	statusUpdate = "update"

--- a/server/webhook/deployment.go
+++ b/server/webhook/deployment.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+func (w *webhook) HandleDeployment(ctx context.Context, event *gitlab.DeploymentEvent) ([]*HandleWebhook, error) {
+	handlers, err := w.handleChannelDeployment(ctx, event)
+	if err != nil {
+		return nil, err
+	}
+	return cleanWebhookHandlers(handlers), nil
+}
+
+func (w *webhook) handleChannelDeployment(ctx context.Context, event *gitlab.DeploymentEvent) ([]*HandleWebhook, error) {
+	senderGitlabUsername := event.User.Username
+	repo := event.Project
+	res := []*HandleWebhook{}
+	message := fmt.Sprintf("### Deployment Stage: **%s**\n", event.Status)
+
+	switch event.Status {
+	case statusRunning:
+		message += fmt.Sprintf(":rocket: **Status**: %s\n", event.Status)
+	case statusCreated:
+		message += fmt.Sprintf(":clock1: **Status**: %s\n", event.Status)
+	case statusSuccess:
+		message += fmt.Sprintf(":large_green_circle: **Status**: %s\n", event.Status)
+	case statusFailed:
+		message += fmt.Sprintf(":red_circle: **Status**: %s\n", event.Status)
+	default:
+		return res, nil
+	}
+	namespaceMetadata, err := normalizeNamespacedProjectByHomepage(event.Project.Homepage)
+	if err != nil {
+		return nil, err
+	}
+	fullNamespacePath := fmt.Sprintf("%s/%s", namespaceMetadata.Namespace, namespaceMetadata.Project)
+	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Project.GitHTTPURL)
+	message += fmt.Sprintf("**Triggered By**: %s\n", senderGitlabUsername)
+	message += fmt.Sprintf("**Visit job [here](%s)** \n", event.DeployableURL)
+	toChannels := make([]string, 0)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		ctx, namespaceMetadata.Namespace, namespaceMetadata.Project,
+		repo.VisibilityLevel == PublicVisibilityLevel,
+	)
+	for _, sub := range subs {
+		if !sub.Deployments() {
+			continue
+		}
+
+		toChannels = append(toChannels, sub.ChannelID)
+	}
+	if len(toChannels) > 0 {
+		res = append(res, &HandleWebhook{
+			From:       senderGitlabUsername,
+			Message:    message,
+			ToUsers:    []string{},
+			ToChannels: toChannels,
+		})
+	}
+
+	return res, nil
+}

--- a/server/webhook/deployment.go
+++ b/server/webhook/deployment.go
@@ -26,6 +26,8 @@ func (w *webhook) handleChannelDeployment(ctx context.Context, event *gitlab.Dep
 		message += fmt.Sprintf(":rocket: **Status**: %s\n", event.Status)
 	case statusCreated:
 		message += fmt.Sprintf(":clock1: **Status**: %s\n", event.Status)
+	case statusCanceled:
+		message += fmt.Sprintf(":no_entry_sign: **Status**: %s\n", event.Status)
 	case statusSuccess:
 		message += fmt.Sprintf(":large_green_circle: **Status**: %s\n", event.Status)
 	case statusFailed:

--- a/server/webhook/release.go
+++ b/server/webhook/release.go
@@ -16,7 +16,7 @@ func (w *webhook) HandleRelease(ctx context.Context, event *gitlab.ReleaseEvent)
 }
 
 func (w *webhook) handleChannelRelease(ctx context.Context, event *gitlab.ReleaseEvent) ([]*HandleWebhook, error) {
-	release := event.Project
+	project := event.Project
 	res := []*HandleWebhook{}
 	message := fmt.Sprintf("### Release: **%s**\n", event.Action)
 
@@ -48,7 +48,7 @@ func (w *webhook) handleChannelRelease(ctx context.Context, event *gitlab.Releas
 	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
 		ctx, namespaceMetadata.Namespace,
 		namespaceMetadata.Project,
-		release.VisibilityLevel == PublicVisibilityLevel,
+		project.VisibilityLevel == PublicVisibilityLevel,
 	)
 	for _, sub := range subs {
 		if !sub.Releases() {

--- a/server/webhook/release.go
+++ b/server/webhook/release.go
@@ -1,0 +1,64 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+func (w *webhook) HandleRelease(ctx context.Context, event *gitlab.ReleaseEvent) ([]*HandleWebhook, error) {
+	handlers, err := w.handleChannelRelease(ctx, event)
+	if err != nil {
+		return nil, err
+	}
+	return cleanWebhookHandlers(handlers), nil
+}
+
+func (w *webhook) handleChannelRelease(ctx context.Context, event *gitlab.ReleaseEvent) ([]*HandleWebhook, error) {
+	repo := event.Project
+	res := []*HandleWebhook{}
+	message := fmt.Sprintf("### Release: **%s**\n", event.Action)
+
+	switch event.Action {
+	case statusCreate:
+		message += fmt.Sprintf(":new: **Status**: %s\n", event.Action)
+	case statusUpdate:
+		message += fmt.Sprintf(":arrows_counterclockwise: **Status**: %s\n", event.Action)
+	case statusDelete:
+		message += fmt.Sprintf(":red_circle: **Status**: %s\n", event.Action)
+	default:
+		return res, nil
+	}
+	namespaceMetadata, err := normalizeNamespacedProjectByHomepage(event.Project.Homepage)
+	if err != nil {
+		return nil, err
+	}
+	fullNamespacePath := fmt.Sprintf("%s/%s", namespaceMetadata.Namespace, namespaceMetadata.Project)
+	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Project.GitHTTPURL)
+	if event.Action != statusDelete {
+		message += fmt.Sprintf("**Release**: [%s](%s)\n", event.Name, event.URL)
+	}
+	toChannels := make([]string, 0)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		ctx, namespaceMetadata.Namespace, namespaceMetadata.Project,
+		repo.VisibilityLevel == PublicVisibilityLevel,
+	)
+	for _, sub := range subs {
+		if !sub.Releases() {
+			continue
+		}
+
+		toChannels = append(toChannels, sub.ChannelID)
+	}
+	if len(toChannels) > 0 {
+		res = append(res, &HandleWebhook{
+			From:       "",
+			Message:    message,
+			ToUsers:    []string{},
+			ToChannels: toChannels,
+		})
+	}
+
+	return res, nil
+}

--- a/server/webhook/release.go
+++ b/server/webhook/release.go
@@ -40,6 +40,8 @@ func (w *webhook) handleChannelRelease(ctx context.Context, event *gitlab.Releas
 	message += fmt.Sprintf("**Repository**: [%s](%s)\n", fullNamespacePath, event.Project.GitHTTPURL)
 	if event.Action != statusDelete {
 		message += fmt.Sprintf("**Release**: [%s](%s)\n", event.Name, event.URL)
+	} else {
+		message += fmt.Sprintf("**Release**: %s\n", event.Name)
 	}
 
 	toChannels := make([]string, 0)

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -45,6 +45,8 @@ type Webhook interface {
 	HandleTag(ctx context.Context, event *gitlab.TagEvent) ([]*HandleWebhook, error)
 	HandlePush(ctx context.Context, event *gitlab.PushEvent) ([]*HandleWebhook, error)
 	HandleJobs(ctx context.Context, event *gitlab.JobEvent) ([]*HandleWebhook, error)
+	HandleRelease(ctx context.Context, event *gitlab.ReleaseEvent) ([]*HandleWebhook, error)
+	HandleDeployment(ctx context.Context, event *gitlab.DeploymentEvent) ([]*HandleWebhook, error)
 }
 
 type webhook struct {

--- a/server/webhook_test.go
+++ b/server/webhook_test.go
@@ -52,6 +52,14 @@ func (fakeWebhookHandler) HandleJobs(_ context.Context, _ *gitlabLib.JobEvent) (
 	return nil, nil
 }
 
+func (fakeWebhookHandler) HandleDeployment(_ context.Context, _ *gitlabLib.DeploymentEvent) ([]*webhook.HandleWebhook, error) {
+	return nil, nil
+}
+
+func (fakeWebhookHandler) HandleRelease(_ context.Context, _ *gitlabLib.ReleaseEvent) ([]*webhook.HandleWebhook, error) {
+	return nil, nil
+}
+
 func TestHandleWebhookBadSecret(t *testing.T) {
 	p := &Plugin{configuration: &configuration{WebhookSecret: "secret"}}
 	req := httptest.NewRequest("POST", "http://example.com/foo", bytes.NewBufferString(""))


### PR DESCRIPTION
### Description
Added support to subscribe to release and deployment.

### Screenshots
![release7AugGitlab](https://github.com/user-attachments/assets/9d53a0a9-17c8-4694-9848-b304e02dd02a)
![image (2)](https://github.com/user-attachments/assets/acbf12a8-ddb9-4542-8747-0eca6502d1e6)



### What to Test
- create a subscription with release and deployment features and test the expected notifications that are received.