### PR TITLE
[MM-517]: Fixed the issue 'Unable to subscribe to groups or subgroups

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -639,10 +639,13 @@ func (p *Plugin) subscriptionsAddCommand(ctx context.Context, info *gitlab.UserI
 		return err.Error()
 	}
 
-	if hasPermission := p.permissionToProject(ctx, info.UserID, namespace, project); !hasPermission {
-		msg := "You don't have the permissions to create subscriptions for this project."
-		p.client.Log.Warn(msg)
-		return msg
+	// Only check the permissions for a project if the project subscription is created (Not a group or a subgroup subscription)
+	if project != "" {
+		if hasPermission := p.permissionToProject(ctx, info.UserID, namespace, project); !hasPermission {
+			msg := "You don't have the permissions to create subscriptions for this project."
+			p.client.Log.Warn(msg)
+			return msg
+		}
 	}
 
 	updatedSubscriptions, subscribeErr := p.Subscribe(info, namespace, project, channelID, features)


### PR DESCRIPTION
#### Summary
1) Added the condition that the permission to the project will only be checked if the subscription to be created is of project-level subscription. 
2) Permission for the group and sub-group is already getting checked in the ResolveNamespaceAndProject function.

#### Ticket Link
Fixes #517 

#### Testing Steps 
1) Create a group, sub-group, and project subscriptions.

