### PR TITLE
[MM-516]: Fixed the plugin crashing on running subscription add command without arguments

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -703,7 +703,7 @@ func (p *Plugin) subscribeCommand(ctx context.Context, parameters []string, chan
 	case commandAdd:
 		features := "merges,issues,tag"
 		if len(parameters) < 2 {
-			return missingOgOrRepoFromSubscribeCommand
+			return missingOrgOrRepoFromSubscribeCommand
 		} else if len(parameters) > 2 {
 			features = strings.Join(parameters[1:], " ")
 		}

--- a/server/command.go
+++ b/server/command.go
@@ -79,7 +79,7 @@ const (
 	projectNotFoundMessage = "Unable to find project with namespace: "
 
 	invalidSubscribeSubCommand          = "Invalid subscribe command. Available commands are add, delete, and list"
-	missingOgOrRepoFromSubscribeCommand = "Please provide the owner[/repo] [features]"
+	missingOgOrRepoFromSubscribeCommand = "Please provide the owner[/repo]"
 
 	invalidPipelinesSubCommand = "Invalid pipelines command. Available commands are run, list"
 )

--- a/server/command.go
+++ b/server/command.go
@@ -78,8 +78,8 @@ const (
 	projectNotFoundError   = "404 {message: 404 Project Not Found}"
 	projectNotFoundMessage = "Unable to find project with namespace: "
 
-	invalidSubscribeSubCommand          = "Invalid subscribe command. Available commands are add, delete, and list"
-	missingOgOrRepoFromSubscribeCommand = "Please provide the owner[/repo]"
+	invalidSubscribeSubCommand           = "Invalid subscribe command. Available commands are add, delete, and list"
+	missingOrgOrRepoFromSubscribeCommand = "Please provide the owner[/repo]"
 
 	invalidPipelinesSubCommand = "Invalid pipelines command. Available commands are run, list"
 )

--- a/server/command.go
+++ b/server/command.go
@@ -78,7 +78,8 @@ const (
 	projectNotFoundError   = "404 {message: 404 Project Not Found}"
 	projectNotFoundMessage = "Unable to find project with namespace: "
 
-	invalidSubscribeSubCommand = "Invalid subscribe command. Available commands are add, delete, and list"
+	invalidSubscribeSubCommand          = "Invalid subscribe command. Available commands are add, delete, and list"
+	missingOgOrRepoFromSubscribeCommand = "Please provide the owner[/repo] [features]"
 
 	invalidPipelinesSubCommand = "Invalid pipelines command. Available commands are run, list"
 )
@@ -701,8 +702,10 @@ func (p *Plugin) subscribeCommand(ctx context.Context, parameters []string, chan
 		return p.subscriptionsListCommand(channelID)
 	case commandAdd:
 		features := "merges,issues,tag"
-		if len(parameters) > 2 {
-			features = strings.Join(parameters[2:], " ")
+		if len(parameters) < 2 {
+			return missingOgOrRepoFromSubscribeCommand
+		} else if len(parameters) > 2 {
+			features = strings.Join(parameters[1:], " ")
 		}
 		// Resolve namespace and project name
 		fullPath := normalizePath(parameters[1], config.GitlabURL)


### PR DESCRIPTION
### Summary
Fixed the plugin crashing on running the subscription add command without arguments

### Ticket link
 Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/516

### What to test
- Run the `/gitlab subscription add` command without providing org or repo

#### Existing behavior
- Plugin crashes, code panics

#### Updated behaviour 
- valid error is received
![Screenshot from 2024-08-14 20-46-53](https://github.com/user-attachments/assets/47fa2d18-4758-448d-b418-02a9517760e0)