### PR TITLE
[MM-523]: Hide UsePreregisteredApplication on on-prem instances

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -27,9 +27,10 @@
                 "key": "UsePreregisteredApplication",
                 "display_name": "Use Preregistered OAuth Application:",
                 "type": "bool",
-                "help_text": "When true, instructs the plugin to use the preregistered GitLab OAuth application - application registration steps can be skipped. Requires [Chimera Proxy](https://github.com/mattermost/chimera) URL to be configured for the server. Can only be used with official gitlab.com. **This setting is intended to be used with Mattermost Cloud instances only.**",
+                "help_text": "When true, instructs the plugin to use the preregistered GitLab OAuth application - application registration steps can be skipped. Requires [Chimera Proxy](https://github.com/mattermost/chimera) URL to be configured for the server. Can only be used with official gitlab.com.",
                 "placeholder": "",
-                "default": false
+                "default": false,
+                "hosting": "cloud"
             },
             {
                 "key": "GitlabURL",


### PR DESCRIPTION
#### Summary
Hide UsePreregisteredApplication on on-prem instances
#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/523
#### Screenshots
##### Existing
![Screenshot from 2024-09-24 17-03-50](https://github.com/user-attachments/assets/9f8bab71-2709-4e07-a2c6-84b95fe6dc6a)
##### Updated
![Screenshot from 2024-09-24 17-04-35](https://github.com/user-attachments/assets/8b821b19-b61b-4f92-9cb2-25473a6db126)


