### PR TITLE
Fixing failing CI by updating golang-ci lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ apply:
 ## Install go tools
 install-go-tools:
 	@echo Installing go tools
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
 	$(GO) install gotest.tools/gotestsum@v1.7.0
 
 ## Runs eslint and golangci-lint


### PR DESCRIPTION
### Summary
Fixing failing CI by updating golangci-lint version from 1.51.1 to 1.55.0
Refer to this [conversation](https://github.com/github/codeql-action/issues/2581) for more reference