### PR TITLE
Fix GetYourProjects to list all accessible projects with issues enabled

### DIFF
--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -674,9 +674,9 @@ func paginateAll(ctx context.Context, perPage int, projects []*internGitlab.Proj
 		}
 
 		projects = append(projects, pageProjects...)
-
+		
 		// resp.CurrentPage >= resp.TotalPages: we have fetched the last page
-        // resp.NextPage == 0: GitLab did not set a next-page number (no further pages)
+		// resp.NextPage == 0: GitLab did not set a next-page number (no further pages)
 		if resp.CurrentPage >= resp.TotalPages || resp.NextPage == 0 {
 			break
 		}

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -661,7 +661,7 @@ func (g *gitlab) GetToDoList(ctx context.Context, user *UserInfo, client *intern
 }
 
 // Helper function for pagination
-func paginateAll(ctx context.Context, perPage int, projects []*internGitlab.Project, listFn listPageFunc,) ([]*internGitlab.Project, error) {
+func paginateAll(ctx context.Context, perPage int, projects []*internGitlab.Project, listFn listPageFunc) ([]*internGitlab.Project, error) {
 	page := 1
 
 	for {

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -661,8 +661,7 @@ func (g *gitlab) GetToDoList(ctx context.Context, user *UserInfo, client *intern
 }
 
 // Helper function for pagination
-func paginateAll(ctx context.Context, perPage int, projects []*internGitlab.Project, listFn listPageFunc,
-	) ([]*internGitlab.Project, error) {
+func paginateAll(ctx context.Context, perPage int, projects []*internGitlab.Project, listFn listPageFunc,) ([]*internGitlab.Project, error) {
 	page := 1
 
 	for {
@@ -676,6 +675,8 @@ func paginateAll(ctx context.Context, perPage int, projects []*internGitlab.Proj
 
 		projects = append(projects, pageProjects...)
 
+		// resp.CurrentPage >= resp.TotalPages: we have fetched the last page
+        // resp.NextPage == 0: GitLab did not set a next-page number (no further pages)
 		if resp.CurrentPage >= resp.TotalPages || resp.NextPage == 0 {
 			break
 		}
@@ -716,7 +717,6 @@ func (g *gitlab) GetYourProjects(ctx context.Context, user *UserInfo, token *oau
 		}
 
 		return paginateAll(ctx, perPage, projects, listFn)
-
 	}
 	// ─── “With Group” branch: list all projects in that group you have access to
 	opts := &internGitlab.ListGroupProjectsOptions{

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -674,7 +674,7 @@ func paginateAll(ctx context.Context, perPage int, projects []*internGitlab.Proj
 		}
 
 		projects = append(projects, pageProjects...)
-		
+
 		// resp.CurrentPage >= resp.TotalPages: we have fetched the last page
 		// resp.NextPage == 0: GitLab did not set a next-page number (no further pages)
 		if resp.CurrentPage >= resp.TotalPages || resp.NextPage == 0 {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
- Replace `Owned:true` with `Membership:true` in ListProjects to include all projects the user belongs to
- Switch ListGroupProjects to use `WithIssuesEnabled:true` and `MinAccessLevel:Guest` instead of `Owned:true`
- Add pagination (Page=1, PerPage=100, loop until all pages fetched) in both branches
- Filter out any project without issue tracking or where the user’s access level is below Guest (10)

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/573

