### PR TITLE
fix: properly retrieve all users that have access to a project

### DIFF
--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -786,7 +786,7 @@ func (g *gitlab) GetProjectMembers(ctx context.Context, user *UserInfo, projectI
 	if err != nil {
 		return nil, err
 	}
-	result, resp, err := client.ProjectMembers.ListProjectMembers(
+	result, resp, err := client.ProjectMembers.ListAllProjectMembers(
 		projectID,
 		nil,
 		internGitlab.WithContext(ctx),


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This fixes an issue related to the available assignees when using the `/gitlab issue create` command. Currently, it only shows you direct project members; this change updates the Gitlab SDK to use `ListAllProjectMembers` instead so that it gets all users with inherited membership to the group.

I'm not sure what downwind effects this will have with other functions that call this, but this would appear to at least fix my issue related to the ticket I linked.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-plugin-gitlab/issues/611

Otherwise, link the JIRA ticket.
-->

