### PR TITLE
Fetch >20 labels & use top-level group milestones

### DIFF
--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -786,7 +786,7 @@ func (g *gitlab) GetProjectMembers(ctx context.Context, user *UserInfo, projectI
 	if err != nil {
 		return nil, err
 	}
-	result, resp, err := client.ProjectMembers.ListProjectMembers(
+	result, resp, err := client.ProjectMembers.ListAllProjectMembers(
 		projectID,
 		nil,
 		internGitlab.WithContext(ctx),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

- Returns all labels for a project (not just the first 20).
- Returns milestones from the project’s top-level group (org-wide), with pagination.
- Milestones are typically used org-wide and are not project level.

#### Changes

- **GetLabels** in server/gitlab/api.go
  - Updated GetLabels() to paginate `client.Labels.ListLabels()` using `ListOptions{PerPage: 100}` and loop on `resp.NextPage` to aggregate all labels.
  - Function: gitlab.*gitlab.GetLabels

- **GetMilestones** in server/gitlab/api.go
  - Resolves the project via client.Projects.GetProject() and derives the top-level group from `project.Namespace.FullPath` (first path segment).
  - If a top-level group exists, uses `client.GroupMilestones.ListGroupMilestones()` with `PerPage: 100` and paginates across all pages.
  - Falls back to project-level `client.Milestones.ListMilestones()` with pagination if no group is found.
  - Function: gitlab.*gitlab.GetMilestones

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

related ticket: https://github.com/mattermost/mattermost-plugin-gitlab/issues/610
