### PR TITLE
Fix/labels & milestones

### DIFF
--- a/check-style.log
+++ b/check-style.log
@@ -1,2 +1,0 @@
-./build/bin/manifest apply
-cd webapp && /opt/homebrew/bin/npm install --verbose

--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -744,7 +744,7 @@ func (g *gitlab) GetYourProjects(ctx context.Context, user *UserInfo, token *oau
 func (g *gitlab) GetLabels(ctx context.Context, user *UserInfo, projectID string, token *oauth2.Token) ([]*internGitlab.Label, error) {
 	client, err := g.GitlabConnect(*token)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to GitLab: %w", err)
 	}
 
 	opts := &internGitlab.ListLabelsOptions{
@@ -754,39 +754,33 @@ func (g *gitlab) GetLabels(ctx context.Context, user *UserInfo, projectID string
 		},
 	}
 
-	var all []*internGitlab.Label
+	var labels []*internGitlab.Label
 	for {
 		page, resp, err := client.Labels.ListLabels(projectID, opts, internGitlab.WithContext(ctx))
 		if respErr := checkResponse(resp); respErr != nil {
-			return nil, respErr
+			return nil, fmt.Errorf("failed to list labels for project %s: %w", projectID, respErr)
 		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list labels for project %s: %w", projectID, err)
 		}
-		all = append(all, page...)
+		labels = append(labels, page...)
 		if resp.NextPage == 0 {
 			break
 		}
 		opts.Page = resp.NextPage
 	}
 
-	return all, nil
+	return labels, nil
 }
 
 // topLevelGroupFromProject returns the top-level group name (first path segment)
 // for a project under a group namespace. Returns empty string if not a group.
 func topLevelGroupFromProject(p *internGitlab.Project) string {
-	if p == nil || p.Namespace == nil {
+	if p == nil || p.Namespace == nil || !strings.EqualFold(p.Namespace.Kind, "group") || p.Namespace.FullPath == "" {
 		return ""
 	}
-	if !strings.EqualFold(p.Namespace.Kind, "group") {
-		return ""
-	}
-	if p.Namespace.FullPath == "" {
-		return ""
-	}
-	parts := strings.Split(p.Namespace.FullPath, "/")
-	return parts[0]
+	first, _, _ := strings.Cut(p.Namespace.FullPath, "/")
+	return first
 }
 
 func convertGroupMilestones(gms []*internGitlab.GroupMilestone) []*internGitlab.Milestone {
@@ -812,19 +806,46 @@ func convertGroupMilestones(gms []*internGitlab.GroupMilestone) []*internGitlab.
 	return out
 }
 
+// listAllProjectMilestones paginates project milestones for the given project.
+func listAllProjectMilestones(ctx context.Context, client *internGitlab.Client, projectID string) ([]*internGitlab.Milestone, error) {
+	popts := &internGitlab.ListMilestonesOptions{
+		ListOptions: internGitlab.ListOptions{
+			Page:    1,
+			PerPage: 100,
+		},
+	}
+
+	var all []*internGitlab.Milestone
+	for {
+		page, resp, err := client.Milestones.ListMilestones(projectID, popts, internGitlab.WithContext(ctx))
+		if respErr := checkResponse(resp); respErr != nil {
+			return nil, fmt.Errorf("failed to list milestones for project %s: %w", projectID, respErr)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list milestones for project %s: %w", projectID, err)
+		}
+		all = append(all, page...)
+		if resp.NextPage == 0 {
+			break
+		}
+		popts.Page = resp.NextPage
+	}
+	return all, nil
+}
+
 func (g *gitlab) GetMilestones(ctx context.Context, user *UserInfo, projectID string, token *oauth2.Token) ([]*internGitlab.Milestone, error) {
 	client, err := g.GitlabConnect(*token)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to GitLab: %w", err)
 	}
 
 	// Resolve project to find its namespace and top-level group
 	project, resp, err := client.Projects.GetProject(projectID, nil, internGitlab.WithContext(ctx))
 	if respErr := checkResponse(resp); respErr != nil {
-		return nil, respErr
+		return nil, fmt.Errorf("failed to get project %s: %w", projectID, respErr)
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get project %s: %w", projectID, err)
 	}
 
 	topGroup := topLevelGroupFromProject(project)
@@ -837,14 +858,18 @@ func (g *gitlab) GetMilestones(ctx context.Context, user *UserInfo, projectID st
 			},
 		}
 
-		var all []*internGitlab.Milestone
+		var (
+			all  []*internGitlab.Milestone
+			page []*internGitlab.GroupMilestone
+			resp *internGitlab.Response
+		)
 		for {
-			page, resp, err := client.GroupMilestones.ListGroupMilestones(topGroup, opts, internGitlab.WithContext(ctx))
+			page, resp, err = client.GroupMilestones.ListGroupMilestones(topGroup, opts, internGitlab.WithContext(ctx))
 			if respErr := checkResponse(resp); respErr != nil {
-				return nil, respErr
+				return nil, fmt.Errorf("failed to list group milestones for %s: %w", topGroup, respErr)
 			}
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to list group milestones for %s: %w", topGroup, err)
 			}
 			all = append(all, convertGroupMilestones(page)...)
 			if resp.NextPage == 0 {
@@ -855,27 +880,9 @@ func (g *gitlab) GetMilestones(ctx context.Context, user *UserInfo, projectID st
 		return all, nil
 	}
 
-	popts := &internGitlab.ListMilestonesOptions{
-		ListOptions: internGitlab.ListOptions{
-			Page:    1,
-			PerPage: 100,
-		},
-	}
-
-	var all []*internGitlab.Milestone
-	for {
-		page, resp, err := client.Milestones.ListMilestones(projectID, popts, internGitlab.WithContext(ctx))
-		if respErr := checkResponse(resp); respErr != nil {
-			return nil, respErr
-		}
-		if err != nil {
-			return nil, err
-		}
-		all = append(all, page...)
-		if resp.NextPage == 0 {
-			break
-		}
-		popts.Page = resp.NextPage
+	all, err := listAllProjectMilestones(ctx, client, projectID)
+	if err != nil {
+		return nil, err
 	}
 	return all, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

- Returns all labels for a project (not just the first 20).
- Returns milestones from the project’s top-level group (org-wide), with pagination.
- Milestones are typically used org-wide and are not project level.

#### Changes

- **GetLabels** in server/gitlab/api.go
  - Updated GetLabels() to paginate `client.Labels.ListLabels()` using `ListOptions{PerPage: 100}` and loop on `resp.NextPage` to aggregate all labels.
  - Function: gitlab.*gitlab.GetLabels

- **GetMilestones** in server/gitlab/api.go
  - Resolves the project via client.Projects.GetProject() and derives the top-level group from `project.Namespace.FullPath` (first path segment).
  - If a top-level group exists, uses `client.GroupMilestones.ListGroupMilestones()` with `PerPage: 100` and paginates across all pages.
  - Falls back to project-level `client.Milestones.ListMilestones()` with pagination if no group is found.
  - Function: gitlab.*gitlab.GetMilestones

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

related ticket: https://github.com/mattermost/mattermost-plugin-gitlab/issues/610
