### PR TITLE
MM-68133 Removing default instance setting on connect

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -342,13 +342,6 @@ func (p *Plugin) handleConnect(args *model.CommandArgs, parameters []string) (*m
 		return p.getCommandResponse(args, "Please specify the instance name.", true), nil
 	}
 
-	// Set the default instance for the user before connecting
-	instanceName := strings.TrimSpace(strings.Join(parameters, " "))
-	err := p.setDefaultInstance(instanceName)
-	if err != nil {
-		return p.getCommandResponse(args, err.Error(), true), nil
-	}
-
 	pluginURL := getPluginURL(p.client)
 	if pluginURL == "" {
 		return p.getCommandResponse(args, "Encountered an error connecting to GitLab.", true), nil

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -764,17 +764,10 @@ func TestInstanceCommands(t *testing.T) {
 	t.Run("connect", func(t *testing.T) {
 		for _, tc := range instanceNameTestCases {
 			t.Run("connect "+tc.name, func(t *testing.T) {
-				instanceList := []string{tc.instanceName}
-				if !tc.exists {
-					instanceList = []string{"Other Instance"}
-				}
-				p, msg, _ := setupInstanceCommandTest(t, instanceList, nil)
+				p, msg, api := setupInstanceCommandTest(t, nil, nil)
 				_, _ = p.handleConnect(args, tc.parameters)
-				if tc.exists {
-					assert.Contains(t, *msg, "Click here to link your GitLab account")
-				} else {
-					assert.Contains(t, *msg, "does not exist")
-				}
+				assert.Contains(t, *msg, "Click here to link your GitLab account")
+				api.AssertNotCalled(t, "SavePluginConfig", mock.Anything)
 			})
 		}
 		t.Run("no parameters", func(t *testing.T) {

--- a/server/flow.go
+++ b/server/flow.go
@@ -33,6 +33,7 @@ type FlowManager struct {
 	createHook                      func(ctx context.Context, gitlabClient gitlab.Gitlab, info *gitlab.UserInfo, group, project string, hookOptions *gitlab.AddWebhookOptions) (*gitlab.WebhookInfo, error)
 	saveInstanceDetails             func(instanceName string, config *InstanceConfiguration) error
 	setDefaultInstance              func(instanceName string) error
+	isAuthorizedSysAdmin            func(userID string) (bool, error)
 
 	setupFlow        *flow.Flow
 	oauthFlow        *flow.Flow
@@ -53,6 +54,7 @@ func (p *Plugin) NewFlowManager() (*FlowManager, error) {
 		createHook:                      p.createHook,
 		saveInstanceDetails:             p.installInstance,
 		setDefaultInstance:              p.setDefaultInstance,
+		isAuthorizedSysAdmin:            p.isAuthorizedSysAdmin,
 	}
 
 	setupFlow, err := fm.newFlow("setup")
@@ -315,6 +317,9 @@ func (fm *FlowManager) stepDelegateQuestion() flow.Step {
 		})
 }
 
+// submitDelegateSelection allows an admin to delegate the setup wizard to another user.
+// The delegated user receives the full flow including stepSetDefaultInstance, which has its
+// own admin check and will block non-admin delegates from modifying the default instance.
 func (fm *FlowManager) submitDelegateSelection(f *flow.Flow, submitted map[string]any) (flow.Name, flow.State, map[string]string, error) {
 	delegateIDRaw, ok := submitted["delegate"]
 	if !ok {
@@ -824,6 +829,14 @@ func (fm *FlowManager) stepSetDefaultInstance() flow.Step {
 			Name:  "Yes",
 			Color: flow.ColorPrimary,
 			OnClick: func(f *flow.Flow) (flow.Name, flow.State, error) {
+				isAdmin, err := fm.isAuthorizedSysAdmin(f.UserID)
+				if err != nil {
+					return "", nil, fmt.Errorf("failed to verify admin privileges: %w", err)
+				}
+				if !isAdmin {
+					return "", nil, fmt.Errorf("only system administrators can set the default instance")
+				}
+
 				if err := fm.setDefaultInstance(fm.instanceName); err != nil {
 					return "", nil, err
 				}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR de-couples the setting of a default instance from the connection flow so that it remains a part of instance setup or something used through its own dedicated command

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-68133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The PR decouples default instance setting from the connect flow and adds authorization checks to the setup flow. While this is a clean architectural improvement, it spans multiple flow management entry points and touches authorization logic in areas affecting user onboarding.

**Regression Risk:** 
- Low risk for the `handleConnect` simplification: removing the auto-setting of default instance is a straightforward change that reduces side effects and makes the connection flow more explicit.
- New admin authorization checks in `stepSetDefaultInstance` could impact users in the setup/oauth flows if they attempt to set a default instance but lack system admin privileges. However, this is an intentional security enhancement and there's a fallback path via the explicit `/gitlab set-default-instance` command.
- The `setDefaultInstance` logic itself is unchanged; only the authorization wrapper was added.
- Test coverage was appropriately updated to verify the new behavior.

**QA Recommendation:** 
Manual QA should focus on the complete setup and OAuth flow sequences with both admin and non-admin users:
1. Verify non-admin users cannot set default instance during setup (new error path)
2. Verify admin users can still set default instance during setup
3. Verify `/gitlab connect` returns OAuth link without any configuration changes
4. Verify the explicit `/gitlab set-default-instance` command still works for admins
5. Test bypass paths when users decline setting default instance in setup flow

Manual QA is recommended due to the authorization gate affecting user workflows, though the scope is bounded to instance setup/onboarding paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->