### PR TITLE
Security: Stateful global regex used for URL validation can cause inconsistent/bypass behavior

### DIFF
--- a/webapp/src/utils/tooltip_utils.ts
+++ b/webapp/src/utils/tooltip_utils.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 // Regex to match if a URl is valid merge request of issue URL
-const gitlabRegexPattern = /https?:\/\/(www\.)?.*\/([\w.?-]+)\/([\w-]+)\/-\/([\w-]+)\/([\d-]+$)/g;
+const gitlabRegexPattern = /https?:\/\/(www\.)?.*\/([\w.?-]+)\/([\w-]+)\/-\/([\w-]+)\/([\d-]+$)/;
 
 export const validateGitlabUrl = (url: string): boolean => {
     return gitlabRegexPattern.test(url);


### PR DESCRIPTION
## Summary

Security: Stateful global regex used for URL validation can cause inconsistent/bypass behavior

## Problem

**Severity**: `Low` | **File**: `webapp/src/utils/tooltip_utils.ts:L5`

`validateGitlabUrl` uses a regex with the global (`/g`) flag and calls `.test()`. In JavaScript, `.test()` with `/g` mutates internal `lastIndex`, causing repeated validations on the same input to alternate unpredictably. This can lead to false negatives/positives and weaken any security decisions based on this validator.

## Solution

Remove the `g` flag for validation regexes or reset `lastIndex` before each `.test()` call. Example: `const re = /.../; return re.test(url);`.

## Changes

- `webapp/src/utils/tooltip_utils.ts` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a targeted one-line security fix that removes stateful regex behavior from a simple URL validation utility. The function is well-tested with comprehensive test coverage, has limited blast radius (used in only one component), and the change fixes inconsistent behavior rather than introducing new risk.

**Regression Risk:** Minimal. The function is isolated to a single utility module with three existing test cases covering valid URLs, invalid URLs, and edge cases. The removal of the `/g` flag actually fixes buggy stateful behavior rather than introducing new behavior. The change is purely internal to the utility with no public API modifications.

**QA Recommendation:** Minimal manual QA required. Automated tests are already in place and should be sufficient. Recommend running the existing test suite (`validateGitlabUrl` tests) to confirm the fix resolves the stateful behavior issue. The change is low-risk enough that skipping additional manual QA is acceptable if automated tests pass, though a quick smoke test of the link tooltip feature in the UI would be prudent given the security context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->