### PR TITLE
MM-68842 Adding extra checks for post creation

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -635,6 +635,10 @@ func (p *Plugin) createIssue(c *UserContext, w http.ResponseWriter, r *http.Requ
 			p.writeAPIError(w, &APIErrorResponse{ID: "", Message: fmt.Sprintf("failed to load post %s : not found", issue.PostID), StatusCode: http.StatusNotFound})
 			return
 		}
+		if !p.client.User.HasPermissionToChannel(c.UserID, post.ChannelId, model.PermissionCreatePost) {
+			p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Not authorized to post in this channel.", StatusCode: http.StatusForbidden})
+			return
+		}
 		permalink = p.getPermalink(issue.PostID)
 	}
 
@@ -715,6 +719,11 @@ func (p *Plugin) attachCommentToIssue(c *UserContext, w http.ResponseWriter, r *
 		return
 	}
 
+	if err := p.validateWebURL(issue.WebURL); err != nil {
+		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: err.Error(), StatusCode: http.StatusBadRequest})
+		return
+	}
+
 	post, appErr := p.API.GetPost(issue.PostID)
 	if appErr != nil {
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: fmt.Sprintf("failed to load post %s", issue.PostID), StatusCode: appErr.StatusCode})
@@ -722,6 +731,11 @@ func (p *Plugin) attachCommentToIssue(c *UserContext, w http.ResponseWriter, r *
 	}
 	if post == nil {
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: fmt.Sprintf("failed to load post %s : not found", issue.PostID), StatusCode: http.StatusNotFound})
+		return
+	}
+
+	if !p.client.User.HasPermissionToChannel(c.UserID, post.ChannelId, model.PermissionCreatePost) {
+		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Not authorized to post in this channel.", StatusCode: http.StatusForbidden})
 		return
 	}
 
@@ -797,6 +811,30 @@ func (p *Plugin) validateCommentBody(issue *gitlab.IssueRequest) error {
 	if issue.Comment == "" {
 		return errors.Errorf("please provide a valid non empty comment")
 	}
+	return nil
+}
+
+func (p *Plugin) validateWebURL(webURL string) error {
+	config := p.getConfiguration()
+	configURL, err := url.Parse(config.GitlabURL)
+	if err != nil {
+		return errors.Errorf("invalid GitLab URL configuration")
+	}
+
+	parsedURL, err := url.Parse(webURL)
+	if err != nil || parsedURL.Host == "" {
+		return errors.Errorf("invalid web_url")
+	}
+
+	if !strings.EqualFold(parsedURL.Host, configURL.Host) {
+		return errors.Errorf("web_url must be a URL under the configured GitLab instance (%s)", config.GitlabURL)
+	}
+
+	gitlabPrefix := strings.TrimRight(config.GitlabURL, "/") + "/"
+	if !strings.HasPrefix(webURL, gitlabPrefix) {
+		return errors.Errorf("web_url must be a URL under the configured GitLab instance (%s)", config.GitlabURL)
+	}
+
 	return nil
 }
 

--- a/server/api.go
+++ b/server/api.go
@@ -826,12 +826,12 @@ func (p *Plugin) validateWebURL(webURL string) error {
 		return errors.Errorf("invalid web_url")
 	}
 
-	if !strings.EqualFold(parsedURL.Host, configURL.Host) {
+	if !strings.EqualFold(parsedURL.Scheme, configURL.Scheme) || !strings.EqualFold(parsedURL.Host, configURL.Host) {
 		return errors.Errorf("web_url must be a URL under the configured GitLab instance (%s)", config.GitlabURL)
 	}
 
-	gitlabPrefix := strings.TrimRight(config.GitlabURL, "/") + "/"
-	if !strings.HasPrefix(webURL, gitlabPrefix) {
+	configPath := strings.TrimRight(configURL.Path, "/") + "/"
+	if !strings.HasPrefix(parsedURL.Path, configPath) {
 		return errors.Errorf("web_url must be a URL under the configured GitLab instance (%s)", config.GitlabURL)
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -826,6 +827,10 @@ func (p *Plugin) validateWebURL(webURL string) error {
 		return errors.Errorf("invalid web_url")
 	}
 
+	if hasInvalidURLChars(webURL) {
+		return errors.Errorf("invalid web_url")
+	}
+
 	if !strings.EqualFold(parsedURL.Scheme, configURL.Scheme) || !strings.EqualFold(parsedURL.Host, configURL.Host) {
 		return errors.Errorf("web_url must be a URL under the configured GitLab instance (%s)", config.GitlabURL)
 	}
@@ -836,6 +841,19 @@ func (p *Plugin) validateWebURL(webURL string) error {
 	}
 
 	return nil
+}
+
+func hasInvalidURLChars(rawURL string) bool {
+	for _, r := range rawURL {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return true
+		}
+		switch r {
+		case '(', ')', '[', ']', '<', '>', '`', '"', '\\':
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Plugin) getPermalink(postID string) string {

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -627,6 +627,23 @@ func TestAttachCommentToIssueReturns400ForInvalidWebURL(t *testing.T) {
 		assert.Contains(t, string(data), "web_url must be a URL under the configured GitLab instance")
 	})
 
+	t.Run("rejects URL with invalid characters", func(t *testing.T) {
+		p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "", nil)
+
+		body := fmt.Sprintf(`{"project_id":123,"iid":1,"post_id":"post_id","comment":"a comment","web_url":"%s/mygroup/repo) name [1]"}`, fakeGitLab.URL)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/attachcommenttoissue", bytes.NewReader([]byte(body)))
+		r.Header.Set("Mattermost-User-ID", "user_id")
+
+		p.ServeHTTP(nil, w, r)
+
+		result := w.Result()
+		defer func() { _ = result.Body.Close() }()
+		data, _ := io.ReadAll(result.Body)
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+		assert.Contains(t, string(data), "invalid web_url")
+	})
+
 	t.Run("accepts valid GitLab URL", func(t *testing.T) {
 		post := &model.Post{Id: "post_id", ChannelId: "channel_id", Message: "msg", UserId: "user_id"}
 		p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "", func(m *plugintest.API) {
@@ -646,4 +663,30 @@ func TestAttachCommentToIssueReturns400ForInvalidWebURL(t *testing.T) {
 		defer func() { _ = result.Body.Close() }()
 		assert.NotEqual(t, http.StatusBadRequest, result.StatusCode)
 	})
+}
+
+func TestHasInvalidURLChars(t *testing.T) {
+	for name, tc := range map[string]struct {
+		url     string
+		invalid bool
+	}{
+		"plain URL":             {"https://gitlab.com/group/repo/-/issues/1", false},
+		"percent-encoded space": {"https://gitlab.com/group/repo%20name/-/issues/1", false},
+		"query and fragment":    {"https://gitlab.com/group/repo/-/issues/1?foo=bar#note_1", false},
+		"raw space":             {"https://gitlab.com/group/repo name", true},
+		"open paren":            {"https://gitlab.com/group/repo(", true},
+		"close paren":           {"https://gitlab.com/group/repo)", true},
+		"square brackets":       {"https://gitlab.com/group/repo[1]", true},
+		"angle brackets":        {"https://gitlab.com/group/repo<b>", true},
+		"backtick":              {"https://gitlab.com/group/repo`", true},
+		"double quote":          {"https://gitlab.com/group/repo\"", true},
+		"backslash":             {"https://gitlab.com/group\\repo", true},
+		"newline":               {"https://gitlab.com/group/repo\nx", true},
+		"tab":                   {"https://gitlab.com/group/repo\tx", true},
+		"non-breaking space":    {"https://gitlab.com/group/repo\u00a0x", true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.invalid, hasInvalidURLChars(tc.url))
+		})
+	}
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -168,6 +169,17 @@ func fakeGitLabServer(t *testing.T, projectPathWithNamespace string) *httptest.S
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(project)
+			return
+		}
+
+		// POST /api/v4/projects/:id/issues/:iid/notes — note creation
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/notes") {
+			note := map[string]any{
+				"id": 1, "body": "test note",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(note)
 			return
 		}
 
@@ -469,10 +481,11 @@ func TestAttachCommentToIssueReturns403WhenNamespaceNotAllowed(t *testing.T) {
 	post := &model.Post{Id: "post_id", ChannelId: "channel_id", Message: "msg", UserId: "user_id"}
 	p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "mygroup", func(m *plugintest.API) {
 		m.On("GetPost", "post_id").Return(post, nil)
+		m.On("HasPermissionToChannel", "user_id", "channel_id", model.PermissionCreatePost).Return(true)
 		m.On("GetUser", "user_id").Return(&model.User{Username: "testuser"}, nil)
 	})
 
-	body := `{"project_id":123,"iid":1,"post_id":"post_id","comment":"a comment","web_url":"https://gitlab.com/group/repo/-/issues/1"}`
+	body := fmt.Sprintf(`{"project_id":123,"iid":1,"post_id":"post_id","comment":"a comment","web_url":"%s/othergroup/repo/-/issues/1"}`, fakeGitLab.URL)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/attachcommenttoissue", bytes.NewReader([]byte(body)))
 	r.Header.Set("Mattermost-User-ID", "user_id")
@@ -484,4 +497,153 @@ func TestAttachCommentToIssueReturns403WhenNamespaceNotAllowed(t *testing.T) {
 	data, _ := io.ReadAll(result.Body)
 	assert.Equal(t, http.StatusForbidden, result.StatusCode)
 	assert.Contains(t, string(data), "only repositories in the mygroup namespace are allowed")
+}
+
+func TestCreateIssueReturns403WhenChannelNotAuthorized(t *testing.T) {
+	fakeGitLab := fakeGitLabServer(t, "mygroup/repo")
+	defer fakeGitLab.Close()
+
+	post := &model.Post{Id: "post_id", ChannelId: "private_channel_id", Message: "msg", UserId: "other_user_id"}
+	p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "", func(m *plugintest.API) {
+		m.On("GetPost", "post_id").Return(post, nil)
+		m.On("HasPermissionToChannel", "user_id", "private_channel_id", model.PermissionCreatePost).Return(false)
+	})
+
+	body := `{"project_id":123,"title":"Test","description":"","post_id":"post_id"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/issue", bytes.NewReader([]byte(body)))
+	r.Header.Set("Mattermost-User-ID", "user_id")
+
+	p.ServeHTTP(nil, w, r)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+	data, _ := io.ReadAll(result.Body)
+	assert.Equal(t, http.StatusForbidden, result.StatusCode)
+	assert.Contains(t, string(data), "Not authorized to post in this channel")
+}
+
+func TestCreateIssueAllowsWhenChannelAuthorized(t *testing.T) {
+	fakeGitLab := fakeGitLabServer(t, "mygroup/repo")
+	defer fakeGitLab.Close()
+
+	post := &model.Post{Id: "post_id", ChannelId: "channel_id", Message: "msg", UserId: "user_id"}
+	p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "", func(m *plugintest.API) {
+		m.On("GetPost", "post_id").Return(post, nil)
+		m.On("HasPermissionToChannel", "user_id", "channel_id", model.PermissionCreatePost).Return(true)
+		m.On("CreatePost", mock.Anything).Return(&model.Post{}, nil)
+	})
+
+	body := `{"project_id":123,"title":"Test","description":"","post_id":"post_id"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/issue", bytes.NewReader([]byte(body)))
+	r.Header.Set("Mattermost-User-ID", "user_id")
+
+	p.ServeHTTP(nil, w, r)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+}
+
+func TestAttachCommentToIssueReturns403WhenChannelNotAuthorized(t *testing.T) {
+	fakeGitLab := fakeGitLabServer(t, "mygroup/repo")
+	defer fakeGitLab.Close()
+
+	post := &model.Post{Id: "post_id", ChannelId: "private_channel_id", Message: "msg", UserId: "other_user_id"}
+	p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "", func(m *plugintest.API) {
+		m.On("GetPost", "post_id").Return(post, nil)
+		m.On("HasPermissionToChannel", "user_id", "private_channel_id", model.PermissionCreatePost).Return(false)
+	})
+
+	body := fmt.Sprintf(`{"project_id":123,"iid":1,"post_id":"post_id","comment":"a comment","web_url":"%s/mygroup/repo/-/issues/1"}`, fakeGitLab.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/attachcommenttoissue", bytes.NewReader([]byte(body)))
+	r.Header.Set("Mattermost-User-ID", "user_id")
+
+	p.ServeHTTP(nil, w, r)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+	data, _ := io.ReadAll(result.Body)
+	assert.Equal(t, http.StatusForbidden, result.StatusCode)
+	assert.Contains(t, string(data), "Not authorized to post in this channel")
+}
+
+func TestAttachCommentToIssueReturns400ForInvalidWebURL(t *testing.T) {
+	fakeGitLab := fakeGitLabServer(t, "mygroup/repo")
+	defer fakeGitLab.Close()
+
+	t.Run("rejects URL from different host", func(t *testing.T) {
+		p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "", nil)
+
+		body := `{"project_id":123,"iid":1,"post_id":"post_id","comment":"a comment","web_url":"https://evil.attacker/phish"}`
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/attachcommenttoissue", bytes.NewReader([]byte(body)))
+		r.Header.Set("Mattermost-User-ID", "user_id")
+
+		p.ServeHTTP(nil, w, r)
+
+		result := w.Result()
+		defer func() { _ = result.Body.Close() }()
+		data, _ := io.ReadAll(result.Body)
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+		assert.Contains(t, string(data), "web_url must be a URL under the configured GitLab instance")
+	})
+
+	t.Run("rejects URL with matching host but wrong path prefix", func(t *testing.T) {
+		config := configuration{
+			GitlabURL:               "https://gitlab.com/myinstance",
+			GitlabOAuthClientID:     "client_id",
+			GitlabOAuthClientSecret: "client_secret",
+			EncryptionKey:           testEncryptionKeyForAPI,
+		}
+		info := gitlab.UserInfo{UserID: "user_id", GitlabUsername: "gitlab_username", GitlabUserID: 0}
+		jsonInfo, err := json.Marshal(info)
+		require.NoError(t, err)
+
+		mockAPI := &plugintest.API{}
+		siteURL := "https://example.com"
+		conf := &model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}}
+		mockAPI.On("GetConfig", mock.Anything).Return(conf)
+		mockAPI.On("KVGet", "user_id_userinfo").Return(jsonInfo, nil)
+
+		p := &Plugin{configuration: &config}
+		p.initializeAPI()
+		p.SetAPI(mockAPI)
+		p.client = pluginapi.NewClient(mockAPI, p.Driver)
+
+		body := `{"project_id":123,"iid":1,"post_id":"post_id","comment":"a comment","web_url":"https://gitlab.com/otherpath/repo/-/issues/1"}`
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/attachcommenttoissue", bytes.NewReader([]byte(body)))
+		r.Header.Set("Mattermost-User-ID", "user_id")
+
+		p.ServeHTTP(nil, w, r)
+
+		result := w.Result()
+		defer func() { _ = result.Body.Close() }()
+		data, _ := io.ReadAll(result.Body)
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+		assert.Contains(t, string(data), "web_url must be a URL under the configured GitLab instance")
+	})
+
+	t.Run("accepts valid GitLab URL", func(t *testing.T) {
+		post := &model.Post{Id: "post_id", ChannelId: "channel_id", Message: "msg", UserId: "user_id"}
+		p := setupNamespaceTestPlugin(t, fakeGitLab.URL, "", func(m *plugintest.API) {
+			m.On("GetPost", "post_id").Return(post, nil)
+			m.On("HasPermissionToChannel", "user_id", "channel_id", model.PermissionCreatePost).Return(true)
+			m.On("GetUser", "user_id").Return(&model.User{Username: "testuser"}, nil)
+		})
+
+		body := fmt.Sprintf(`{"project_id":123,"iid":1,"post_id":"post_id","comment":"a comment","web_url":"%s/mygroup/repo/-/issues/1"}`, fakeGitLab.URL)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/attachcommenttoissue", bytes.NewReader([]byte(body)))
+		r.Header.Set("Mattermost-User-ID", "user_id")
+
+		p.ServeHTTP(nil, w, r)
+
+		result := w.Result()
+		defer func() { _ = result.Body.Close() }()
+		assert.NotEqual(t, http.StatusBadRequest, result.StatusCode)
+	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds extra steps for call handlers when processing issue creation requests and adds unit tests to prevent any regressions

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-68842


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Reasoning:** The PR introduces channel-level authorization checks to core issue and comment creation handlers and strict GitLab URL validation, changing response behavior (new 400/403 outcomes) for existing flows and affecting critical security/authorization paths.

**Regression Risk:** High — changes touch authentication/authorization for widely-used endpoints (`createIssue`, `attachCommentToIssue`) and introduce failure modes for previously-allowed requests; although unit tests were added, integrations and external workflows may be impacted.

**QA Recommendation:** Thorough manual QA required. Validate:
- Issue and comment creation with users/bots that have and lack channel post permissions (expect success vs 403).
- WebURL validation across allowed GitLab instance URLs, mismatched hosts, wrong path prefixes, and inputs with invalid characters (expect acceptance vs 400).
- Existing integrations and automation that rely on these endpoints in a staging environment before production rollout.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->