### PR TITLE
MM-70042: Improve project handling in the GitLab integration

### DIFF
--- a/server/gitlab/api.go
+++ b/server/gitlab/api.go
@@ -325,6 +325,9 @@ func (g *gitlab) GetProject(ctx context.Context, user *UserInfo, token *oauth2.T
 	if err != nil {
 		return nil, err
 	}
+	if err = g.checkGroup(project.PathWithNamespace); err != nil {
+		return nil, err
+	}
 
 	return project, nil
 }

--- a/server/mcp_test.go
+++ b/server/mcp_test.go
@@ -5,8 +5,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -20,7 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 	internGitlab "github.com/xanzy/go-gitlab"
 	gomock "go.uber.org/mock/gomock"
+	"golang.org/x/oauth2"
 
+	gitlabapi "github.com/mattermost/mattermost-plugin-gitlab/server/gitlab"
 	mockgitlab "github.com/mattermost/mattermost-plugin-gitlab/server/mocks"
 )
 
@@ -392,6 +396,69 @@ func TestHandleAddComment_Validation(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.errSub)
 		})
 	}
+}
+
+// --- GetProject group-containment gate tests --------------------------------
+
+func TestGetProject_GroupGate(t *testing.T) {
+	newProjectServer := func(projectPath string) *httptest.Server {
+		h := http.NewServeMux()
+		h.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodGet && req.URL.Path == "/api/v4/projects/"+projectPath {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":                  4242,
+					"name":                "repo",
+					"path_with_namespace": projectPath,
+					"visibility":          "private",
+					"default_branch":      "main",
+				})
+				return
+			}
+			http.NotFound(w, req)
+		})
+		return httptest.NewServer(h)
+	}
+
+	newClient := func(group, projectPath string) (gitlabapi.Gitlab, *httptest.Server) {
+		server := newProjectServer(projectPath)
+		checkGroup := func(ns string) error {
+			p := &Plugin{}
+			p.configuration = &configuration{GitlabGroup: group}
+			return p.isNamespaceAllowed(ns)
+		}
+		u, _ := url.Parse(server.URL)
+		return gitlabapi.New(u.String(), group, checkGroup), server
+	}
+
+	ctx := context.Background()
+	info := &gitlabapi.UserInfo{UserID: "mm-user"}
+	token := &oauth2.Token{AccessToken: "tok"}
+
+	t.Run("out-of-group project blocked when group configured", func(t *testing.T) {
+		client, server := newClient("allowed-group", "external-corp/private-secrets")
+		defer server.Close()
+		project, err := client.GetProject(ctx, info, token, "external-corp", "private-secrets")
+		require.Error(t, err)
+		assert.Nil(t, project)
+	})
+
+	t.Run("in-group project allowed when group configured", func(t *testing.T) {
+		client, server := newClient("allowed-group", "allowed-group/my-repo")
+		defer server.Close()
+		project, err := client.GetProject(ctx, info, token, "allowed-group", "my-repo")
+		require.NoError(t, err)
+		require.NotNil(t, project)
+		assert.Equal(t, "allowed-group/my-repo", project.PathWithNamespace)
+	})
+
+	t.Run("no group configured allows any project", func(t *testing.T) {
+		client, server := newClient("", "external-corp/private-secrets")
+		defer server.Close()
+		project, err := client.GetProject(ctx, info, token, "external-corp", "private-secrets")
+		require.NoError(t, err)
+		require.NotNil(t, project)
+		assert.Equal(t, "external-corp/private-secrets", project.PathWithNamespace)
+	})
 }
 
 // --- Conversion helper tests ------------------------------------------------

--- a/server/mcp_test.go
+++ b/server/mcp_test.go
@@ -405,7 +405,7 @@ func TestGetProject_GroupGate(t *testing.T) {
 		h := http.NewServeMux()
 		h.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodGet && req.URL.Path == "/api/v4/projects/"+projectPath {
-				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				_ = json.NewEncoder(w).Encode(map[string]any{
 					"id":                  4242,
 					"name":                "repo",
 					"path_with_namespace": projectPath,

--- a/server/permalinks.go
+++ b/server/permalinks.go
@@ -102,6 +102,11 @@ func (p *Plugin) processReplacement(r replacement, glClient *gitlab.Client, wg *
 	}
 	projectPath := fmt.Sprintf("%s/%s", r.permalinkData.user, r.permalinkData.repo)
 
+	// Skip previews for projects outside the configured GitLab group.
+	if err := p.isNamespaceAllowed(projectPath); err != nil {
+		return
+	}
+
 	// Check if the project is public
 	if p.getConfiguration().EnableCodePreview == "public" {
 		repo, _, err := glClient.Projects.GetProject(projectPath, &gitlab.GetProjectOptions{})

--- a/server/permalinks_test.go
+++ b/server/permalinks_test.go
@@ -367,6 +367,52 @@ func TestMakeReplacements(t *testing.T) {
 	}
 }
 
+func TestMakeReplacementsNamespaceGate(t *testing.T) {
+	input := "start https://gitlab.com/mattermost/mattermost-server/-/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum"
+
+	newPlugin := func(group string) *Plugin {
+		p := NewPlugin()
+		p.configuration = &configuration{
+			EnableCodePreview: "privateAndPublic",
+			GitlabGroup:       group,
+		}
+		mockPluginAPI := &plugintest.API{}
+		mockPluginAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+		mockPluginAPI.On("LogWarn", mock.Anything, mock.Anything).Maybe()
+		p.SetAPI(mockPluginAPI)
+		return p
+	}
+
+	client, closer := getClient()
+	defer closer()
+
+	t.Run("out-of-group project skips preview when group configured", func(t *testing.T) {
+		p := newPlugin("other-group")
+		replacements := p.getPermalinkReplacements(input)
+		require.Len(t, replacements, 1)
+		out := p.makeReplacements(input, replacements, client)
+		assert.Equal(t, input, out, "out-of-group permalink must be left untouched")
+	})
+
+	t.Run("in-group project still renders preview", func(t *testing.T) {
+		p := newPlugin("mattermost")
+		replacements := p.getPermalinkReplacements(input)
+		require.Len(t, replacements, 1)
+		out := p.makeReplacements(input, replacements, client)
+		assert.NotEqual(t, input, out, "in-group permalink must be expanded")
+		assert.Contains(t, out, "TokenLocation")
+	})
+
+	t.Run("no group configured renders preview", func(t *testing.T) {
+		p := newPlugin("")
+		replacements := p.getPermalinkReplacements(input)
+		require.Len(t, replacements, 1)
+		out := p.makeReplacements(input, replacements, client)
+		assert.NotEqual(t, input, out, "with no group configured previews must still work")
+		assert.Contains(t, out, "TokenLocation")
+	})
+}
+
 const (
 	baseURLPath    = "/api/v4"
 	requestURLPath = "/api/v4/projects/mattermost/mattermost-server/repository/files/app/authentication.go"


### PR DESCRIPTION
See [MM-70045](https://mattermost.atlassian.net/browse/MM-70045) for more details.

```release-note
Fixed an issue with project handling in the GitLab integration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The change adds extra namespace/group gating to GitLab project retrieval and permalink preview generation, which directly affects user-facing project access and code preview behavior across multiple components. Existing automated tests cover the primary in-group/out-of-group/unconfigured scenarios, but there’s still moderate risk of blocking or altering edge-case namespaces.

**Regression Risk:** Moderate—behavior changes occur in core GitLab integration logic (project fetching and permalink processing), and failures in the new validation could impact previews even when the initial fetch succeeds.

**QA Recommendation:** Perform focused manual QA for in-group vs out-of-group vs unconfigured GitlabGroup permutations, especially around permalink preview expansion. Skipping manual QA is not recommended due to the user-facing behavioral change, though automated tests should catch many regressions.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MM-70045]: https://mattermost.atlassian.net/browse/MM-70045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ