### PR TITLE
Fix lost-update race in channel subscriptions

### DIFF
--- a/server/subscription_race_test.go
+++ b/server/subscription_race_test.go
@@ -111,4 +111,11 @@ func TestSubscriptionRace(t *testing.T) {
 	if silentlyLost > 0 {
 		t.Fatalf("lost-update bug: %d subscriptions were reported as saved but silently dropped", silentlyLost)
 	}
+
+	// Guard against a false pass: if every AddSubscription call failed,
+	// reportedSuccess and persisted are both 0, so silentlyLost is 0 and the
+	// check above passes without actually exercising the race.
+	if reportedSuccess == 0 {
+		t.Fatalf("no AddSubscription calls succeeded; the race was not exercised")
+	}
 }

--- a/server/subscription_race_test.go
+++ b/server/subscription_race_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+
+	"github.com/mattermost/mattermost-plugin-gitlab/server/subscription"
+)
+
+// raceKVAPI is an in-memory plugin.API whose KVGet and KVSetWithOptions
+// implement real compare-and-set semantics, so SetAtomicWithRetries behaves
+// exactly as it does against the server KV store. Every other API method is
+// inherited from plugintest.API and is unused by the subscription store.
+type raceKVAPI struct {
+	plugintest.API
+	mu    sync.Mutex
+	store map[string][]byte
+}
+
+func newRaceKVAPI() *raceKVAPI {
+	return &raceKVAPI{store: map[string][]byte{}}
+}
+
+func (a *raceKVAPI) KVGet(key string) ([]byte, *model.AppError) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.store[key], nil
+}
+
+func (a *raceKVAPI) KVSetWithOptions(key string, value []byte, options model.PluginKVSetOptions) (bool, *model.AppError) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if options.Atomic {
+		if !bytes.Equal(a.store[key], options.OldValue) {
+			return false, nil
+		}
+	}
+
+	if value == nil {
+		delete(a.store, key)
+	} else {
+		a.store[key] = value
+	}
+	return true, nil
+}
+
+// TestSubscriptionRace drives the plugin's real AddSubscription against an
+// in-memory KV store with real compare-and-set semantics. Many channels
+// subscribe to the same repository concurrently; afterwards we compare how many
+// AddSubscription calls reported success (nil error) against how many
+// subscriptions actually persisted.
+//
+// Correct behaviour: persisted == reported-success (every reported success is
+// durable). Before the fix, StoreSubscriptions did a plain non-atomic Set and
+// swallowed the error, so concurrent writers clobbered each other and persisted
+// was far lower than reported-success (silent lost updates).
+func TestSubscriptionRace(t *testing.T) {
+	const numChannels = 200
+
+	api := newRaceKVAPI()
+	p := &Plugin{configuration: &configuration{}}
+	p.SetAPI(api)
+	p.client = pluginapi.NewClient(api, p.Driver)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	reportedSuccess := 0
+
+	for i := 0; i < numChannels; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sub := &subscription.Subscription{
+				ChannelID:  fmt.Sprintf("channel-%d", i),
+				Repository: "namespace/project",
+			}
+			if _, err := p.AddSubscription("namespace/project", sub); err == nil {
+				mu.Lock()
+				reportedSuccess++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	subs, err := p.GetSubscriptions()
+	if err != nil {
+		t.Fatalf("GetSubscriptions failed: %v", err)
+	}
+	persisted := 0
+	for _, chans := range subs.Repositories {
+		persisted += len(chans)
+	}
+
+	silentlyLost := reportedSuccess - persisted
+	t.Logf("concurrent AddSubscription calls : %d", numChannels)
+	t.Logf("AddSubscription returned success : %d", reportedSuccess)
+	t.Logf("subscriptions actually persisted : %d", persisted)
+	t.Logf("silently lost (success but gone) : %d", silentlyLost)
+
+	if silentlyLost > 0 {
+		t.Fatalf("lost-update bug: %d subscriptions were reported as saved but silently dropped", silentlyLost)
+	}
+}

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/pkg/errors"
 
@@ -63,31 +64,28 @@ func filterSubscriptionsByChannel(subs *Subscriptions, channelID string) []*subs
 }
 
 func (p *Plugin) AddSubscription(fullPath string, sub *subscription.Subscription) (*Subscriptions, error) {
-	subs, err := p.GetSubscriptions()
-	if err != nil {
-		return nil, err
-	}
+	return p.modifySubscriptions(func(subs *Subscriptions) error {
+		repoSubs := subs.Repositories[fullPath]
+		if repoSubs == nil {
+			repoSubs = []*subscription.Subscription{sub}
+		} else {
+			exists := false
+			for index, s := range repoSubs {
+				if s.ChannelID == sub.ChannelID {
+					repoSubs[index] = sub
+					exists = true
+					break
+				}
+			}
 
-	repoSubs := subs.Repositories[fullPath]
-	if repoSubs == nil {
-		repoSubs = []*subscription.Subscription{sub}
-	} else {
-		exists := false
-		for index, s := range repoSubs {
-			if s.ChannelID == sub.ChannelID {
-				repoSubs[index] = sub
-				exists = true
-				break
+			if !exists {
+				repoSubs = append(repoSubs, sub)
 			}
 		}
 
-		if !exists {
-			repoSubs = append(repoSubs, sub)
-		}
-	}
-
-	subs.Repositories[fullPath] = repoSubs
-	return subs, p.StoreSubscriptions(subs)
+		subs.Repositories[fullPath] = repoSubs
+		return nil
+	})
 }
 
 func (p *Plugin) GetSubscriptions() (*Subscriptions, error) {
@@ -106,11 +104,44 @@ func (p *Plugin) GetSubscriptions() (*Subscriptions, error) {
 	return subscriptions, nil
 }
 
-func (p *Plugin) StoreSubscriptions(s *Subscriptions) error {
-	if _, err := p.client.KV.Set(SubscriptionsKey, s); err != nil {
-		p.client.Log.Warn("can't set subscriptions in kvstore", "err", err.Error())
+// errStopModify is a sentinel returned from a modifySubscriptions mutate
+// function to abort the atomic write without performing it and without treating
+// it as a store failure. SetAtomicWithRetries returns immediately (no retry)
+// when the callback errors, so the caller distinguishes this from a real error.
+var errStopModify = errors.New("stop modifying subscriptions")
+
+// modifySubscriptions performs an atomic read-modify-write of the whole
+// subscriptions blob. The mutate function runs inside SetAtomicWithRetries'
+// callback, so on every retry it receives the freshly re-read state and
+// re-applies its change on top of it. This prevents concurrent mutations across
+// channels from silently clobbering one another (lost updates). It returns the
+// resulting subscriptions on success.
+func (p *Plugin) modifySubscriptions(mutate func(*Subscriptions) error) (*Subscriptions, error) {
+	var result *Subscriptions
+
+	err := p.client.KV.SetAtomicWithRetries(SubscriptionsKey, func(oldValue []byte) (any, error) {
+		subs := &Subscriptions{Repositories: map[string][]*subscription.Subscription{}}
+		if len(oldValue) > 0 {
+			if err := json.Unmarshal(oldValue, subs); err != nil {
+				return nil, errors.Wrap(err, "can't unmarshal subscriptions from kvstore")
+			}
+			if subs.Repositories == nil {
+				subs.Repositories = map[string][]*subscription.Subscription{}
+			}
+		}
+
+		if err := mutate(subs); err != nil {
+			return nil, err
+		}
+
+		result = subs
+		return subs, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return nil
+
+	return result, nil
 }
 
 func (p *Plugin) GetSubscribedChannelsForProject(
@@ -161,41 +192,55 @@ func (p *Plugin) Unsubscribe(channelID string, fullPath string) (bool, *Subscrip
 		return false, nil, errors.New("invalid repository")
 	}
 
-	subs, err := p.GetSubscriptions()
+	var removed bool
+	var current *Subscriptions
+
+	subs, err := p.modifySubscriptions(func(subs *Subscriptions) error {
+		removed = false
+		current = subs
+
+		// We don't know whether fullPath is a namespace or project, so we have to check both cases
+		for _, path := range []string{fullPath, fullPath + "/"} {
+			pathSubs := subs.Repositories[path]
+			if pathSubs == nil {
+				continue
+			}
+
+			pathRemoved := false
+			for index, sub := range pathSubs {
+				if sub.ChannelID == channelID {
+					pathSubs = append(pathSubs[:index], pathSubs[index+1:]...)
+					pathRemoved = true
+					break
+				}
+			}
+
+			if pathRemoved {
+				if len(pathSubs) > 0 {
+					subs.Repositories[path] = pathSubs
+				} else {
+					delete(subs.Repositories, path)
+				}
+				removed = true
+			}
+		}
+
+		if !removed {
+			return errStopModify
+		}
+
+		return nil
+	})
+
 	if err != nil {
+		// errStopModify signals that no matching subscription existed; that is a
+		// no-op, not a failure. Any other error is a real store/read failure and
+		// must be surfaced instead of being reported as "not subscribed".
+		if errors.Cause(err) == errStopModify {
+			return false, current, nil
+		}
 		return false, nil, err
 	}
 
-	var removed bool
-
-	// We don't know whether fullPath is a namespace or project, so we have to check both cases
-	for _, path := range []string{fullPath, fullPath + "/"} {
-		pathSubs := subs.Repositories[path]
-		if pathSubs == nil {
-			continue
-		}
-
-		pathRemoved := false
-		for index, sub := range pathSubs {
-			if sub.ChannelID == channelID {
-				pathSubs = append(pathSubs[:index], pathSubs[index+1:]...)
-				pathRemoved = true
-				break
-			}
-		}
-
-		if pathRemoved {
-			if len(pathSubs) > 0 {
-				subs.Repositories[path] = pathSubs
-			} else {
-				delete(subs.Repositories, path)
-			}
-			removed = true
-		}
-	}
-
-	if !removed {
-		return false, subs, nil
-	}
-	return true, subs, p.StoreSubscriptions(subs)
+	return true, subs, nil
 }


### PR DESCRIPTION
# Fix lost-update race in channel subscriptions

## Summary

All channel subscriptions are stored in a single KV key (`subscriptions`).
Every mutation reads the whole blob, changes it in memory, and writes the whole
blob back. That read-modify-write was not atomic, so two subscribe or
unsubscribe operations running at the same time in different channels could
overwrite each other. Both callers were told the operation succeeded, but only
one of the two changes actually persisted. The other was silently lost.

## Root cause

`StoreSubscriptions` in `server/subscriptions.go` wrote the whole blob with a
plain `Set` and no compare-and-set, and it also swallowed any write error:

```go
// server/subscriptions.go (before)
func (p *Plugin) StoreSubscriptions(s *Subscriptions) error {
	if _, err := p.client.KV.Set(SubscriptionsKey, s); err != nil {
		p.client.Log.Warn("can't set subscriptions in kvstore", "err", err.Error())
	}
	return nil   // always reports success, even when the write failed
}
```

`AddSubscription` (`subscriptions.go:65`) and `Unsubscribe`
(`subscriptions.go:159`) both did `GetSubscriptions()` to read the whole blob,
mutated the in-memory copy, then handed that copy to `StoreSubscriptions`.

Because the write used a plain `Set`, a concurrent writer that had read the same
starting blob would overwrite the first writer's change with its own copy. The
last write won and every earlier change was dropped. Since the error was
swallowed, a genuinely failed write also reported success.

## The fix

Switch to the atomic `SetAtomicWithRetries` pattern exposed by the pluginapi KV
service, and move the read-modify-write inside its callback. A new
`modifySubscriptions` helper decodes `oldValue` on every attempt, applies a
mutate closure to that fresh state, and returns the re-encoded result. On a
conflicting write the retry re-reads the latest blob and re-applies the change,
so nothing is lost. The real store error is now returned to the caller instead
of being swallowed.

`AddSubscription` and `Unsubscribe` now express their change as a mutate closure
and keep their existing return signatures (`Unsubscribe` still reports whether a
subscription was removed and returns the resulting subscriptions).
`GetSubscriptions` and `GetSubscriptionsByChannel` are unchanged.

## Regression test

`TestSubscriptionRace` (`server/subscription_race_test.go`) fires 200 concurrent
`AddSubscription` calls against an in-memory KV store whose `KVGet` and
`KVSetWithOptions` implement real compare-and-set semantics, matching the server
KV store. It then compares how many calls reported success against how many
subscriptions actually persisted. It fails on the old code and passes with this
fix.

### Before the fix

```
=== RUN   TestSubscriptionRace
    subscription_race_test.go:106: concurrent AddSubscription calls : 200
    subscription_race_test.go:107: AddSubscription returned success : 200
    subscription_race_test.go:108: subscriptions actually persisted : 10
    subscription_race_test.go:109: silently lost (success but gone) : 190
    subscription_race_test.go:112: lost-update bug: 190 subscriptions were reported as saved but silently dropped
--- FAIL: TestSubscriptionRace (0.00s)
FAIL
```

All 200 calls reported success because the old code swallowed write errors, yet
only 10 subscriptions persisted.

### After the fix

```
=== RUN   TestSubscriptionRace
    subscription_race_test.go:106: concurrent AddSubscription calls : 200
    subscription_race_test.go:107: AddSubscription returned success : 123
    subscription_race_test.go:108: subscriptions actually persisted : 123
    subscription_race_test.go:109: silently lost (success but gone) : 0
--- PASS: TestSubscriptionRace (0.06s)
```

After the fix, every call that reports success is durable. Under heavy
contention some calls exhaust the five internal retries and return an error
instead. Those are reported as failures and are not counted as success, which is
the correct behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Reasoning:** The change modifies subscription persistence and concurrency handling. The scope is isolated, but it affects data integrity and removes the public `StoreSubscriptions` method.

**Regression Risk:** Medium. The atomic write flow changes `AddSubscription` and `Unsubscribe`, including error handling and removal behavior. A concurrency regression test covers concurrent additions, but other mutation paths remain less covered.

** QA Recommendation:** Perform focused manual QA for concurrent updates, replacements, unsubscriptions, store errors, and consumers of `StoreSubscriptions`. Skipping manual QA carries moderate risk because the change affects persisted subscription data.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->