### PR TITLE
Use constant-time comparison for GitLab webhook secret

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +66,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
 	signature := r.Header.Get("X-Gitlab-Token")
-	if config.WebhookSecret != signature {
+	if subtle.ConstantTimeCompare([]byte(config.WebhookSecret), []byte(signature)) != 1 {
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
 		return
 	}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"fmt"
 	"io"
@@ -66,7 +67,12 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
 	signature := r.Header.Get("X-Gitlab-Token")
-	if subtle.ConstantTimeCompare([]byte(config.WebhookSecret), []byte(signature)) != 1 {
+	// Compare fixed-length SHA-256 digests rather than the raw values:
+	// subtle.ConstantTimeCompare returns 0 immediately when the inputs differ
+	// in length, which would leak the length of the configured secret.
+	secretDigest := sha256.Sum256([]byte(config.WebhookSecret))
+	tokenDigest := sha256.Sum256([]byte(signature))
+	if subtle.ConstantTimeCompare(secretDigest[:], tokenDigest[:]) != 1 {
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
## Summary
`handleWebhook` compares the configured `WebhookSecret` against the incoming `X-Gitlab-Token` header with a plain `!=` string comparison. Go's string inequality is not constant-time (it can return as soon as it hits a differing byte), which leaks timing information about the secret on an endpoint that has no other authentication.

Fix: use `subtle.ConstantTimeCompare`, matching the pattern the sibling GitHub plugin already uses (`hmac.Equal`) for its own webhook signature check.

## Test plan
- [x] Existing `TestHandleWebhookBadSecret` and the valid-secret webhook tests in `server/webhook_test.go` cover both branches; behavior is unchanged (only the comparison mechanism changed, not its outcome for equal/unequal inputs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The change affects webhook authentication but remains isolated to one module. Existing tests cover valid and invalid secrets, and the unauthorized response remains unchanged.

**Regression Risk:** Low. The comparison uses fixed-length SHA-256 digests and preserves the existing validation result.

** QA Recommendation:** Focused manual QA is recommended for valid, invalid, and near-match `X-Gitlab-Token` values. Skipping manual QA presents low functional risk.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->