### PR TITLE
Revert "Bump fast-uri from 3.1.4 to 3.1.5 in /webapp"

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -7372,9 +7372,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
Reverts mattermost/mattermost-plugin-gitlab#693