### PR TITLE
Persist the GitLab URL from the setup flow to the plugin configuration

### DIFF
--- a/server/flow.go
+++ b/server/flow.go
@@ -806,8 +806,6 @@ func (fm *FlowManager) submitChannelAnnouncement(f *flow.Flow, submitted map[str
 }
 
 func (fm *FlowManager) setGitlabURL(gitlabURL string) error {
-	fm.gitlabURL = gitlabURL
-
 	config := fm.getConfiguration().Clone()
 	config.GitlabURL = gitlabURL
 
@@ -820,6 +818,8 @@ func (fm *FlowManager) setGitlabURL(gitlabURL string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to save plugin config")
 	}
+
+	fm.gitlabURL = gitlabURL
 
 	return nil
 }

--- a/server/flow.go
+++ b/server/flow.go
@@ -421,7 +421,9 @@ func (fm *FlowManager) submitGitlabURL(f *flow.Flow, submitted map[string]any) (
 		return "", nil, errorList, nil
 	}
 
-	fm.gitlabURL = gitlabURL
+	if err := fm.setGitlabURL(gitlabURL); err != nil {
+		return "", nil, nil, errors.Wrap(err, "failed to save GitLab URL")
+	}
 
 	return "", flow.State{
 		keyGitlabURL: gitlabURL,
@@ -806,8 +808,8 @@ func (fm *FlowManager) submitChannelAnnouncement(f *flow.Flow, submitted map[str
 func (fm *FlowManager) setGitlabURL(gitlabURL string) error {
 	fm.gitlabURL = gitlabURL
 
-	// will need to get gitlab url from plugin config
-	config := fm.getConfiguration()
+	config := fm.getConfiguration().Clone()
+	config.GitlabURL = gitlabURL
 
 	configMap, err := config.ToMap()
 	if err != nil {

--- a/server/flow_test.go
+++ b/server/flow_test.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +40,27 @@ func TestSetGitlabURL(t *testing.T) {
 	assert.Equal(t, "https://git.example.com", savedConfig["gitlaburl"])
 
 	assert.Equal(t, "https://gitlab.com", config.GitlabURL)
+
+	api.AssertExpectations(t)
+}
+
+func TestSetGitlabURLSaveFailure(t *testing.T) {
+	config := &configuration{
+		GitlabURL: "https://gitlab.com",
+	}
+
+	api := &plugintest.API{}
+	api.On("SavePluginConfig", mock.Anything).Return(model.NewAppError("SavePluginConfig", "app.plugin.config.app_error", nil, "", http.StatusInternalServerError)).Once()
+
+	fm := &FlowManager{
+		client:           pluginapi.NewClient(api, nil),
+		getConfiguration: func() *configuration { return config },
+	}
+
+	err := fm.setGitlabURL("https://git.example.com")
+	require.Error(t, err)
+
+	assert.Empty(t, fm.gitlabURL)
 
 	api.AssertExpectations(t)
 }

--- a/server/flow_test.go
+++ b/server/flow_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetGitlabURL(t *testing.T) {
+	config := &configuration{
+		GitlabURL: "https://gitlab.com",
+	}
+
+	var savedConfig map[string]any
+	api := &plugintest.API{}
+	api.On("SavePluginConfig", mock.Anything).Run(func(args mock.Arguments) {
+		savedConfig = args.Get(0).(map[string]any)
+	}).Return(nil).Once()
+
+	fm := &FlowManager{
+		client:           pluginapi.NewClient(api, nil),
+		getConfiguration: func() *configuration { return config },
+	}
+
+	err := fm.setGitlabURL("https://git.example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://git.example.com", fm.gitlabURL)
+
+	require.NotNil(t, savedConfig)
+	assert.Equal(t, "https://git.example.com", savedConfig["gitlaburl"])
+
+	assert.Equal(t, "https://gitlab.com", config.GitlabURL)
+
+	api.AssertExpectations(t)
+}


### PR DESCRIPTION
#### Summary

Running `/setup` and choosing a custom (self-hosted) GitLab URL stored the URL only on the in-memory `FlowManager` and in the KV instance configuration — it never reached the plugin settings. The GitLab API client is rebuilt from `config.GitlabURL` in `OnConfigurationChange`, so it stayed pointed at `https://gitlab.com`.

As a result, the OAuth authorize/token steps went to the self-hosted instance (through the KV instance credentials), but the follow-up `GET /api/v4/user` was sent to gitlab.com with the self-hosted token and failed:

> unable to connect user to GitLab: GET https://gitlab.com/api/v4/user: 401

This also matches the reporter's workaround: configuring the URL through the System Console (which does write the plugin setting) makes the connection work.

Changes:

- `submitGitlabURL` now persists the submitted URL through `setGitlabURL` instead of only assigning the in-memory field.
- `setGitlabURL` writes the URL into the saved plugin configuration — previously it saved the configuration map untouched (leftover TODO). The configuration is cloned first, following the concurrency strategy documented in `configuration.go`.
- Added a unit test asserting the URL reaches the saved plugin settings.

`make test` passes (382 tests).

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/37497


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The change updates plugin configuration persistence in the `/setup` flow. It affects a user-facing GitLab connection path but remains isolated to the flow manager and its tests.

**Regression Risk:** The risk is moderate because the change alters configuration saving behavior. Unit tests cover successful saves and save failures. Manual validation should confirm both hosted and self-hosted GitLab setup flows.

** QA Recommendation:** Perform focused manual QA for custom GitLab URLs and verify API requests use the saved URL. Skipping manual QA carries a moderate risk of missing integration-specific configuration issues.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->