### PR TITLE
MM-67255 Added support to issue assigned events to webhook subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can specify which events trigger a notification. They can see:
 - tag - include tag creation
 - pull_reviews - includes merge request reviews
 - merge_request_assigns - includes merge request assignment and unassignment notifications
+- issue_assigns - includes issue assignment and unassignment notifications
 - label:"<labelname>" - must include "merges" or "issues" in feature list when using a label
 - Defaults to "merges,issues,tag"
 

--- a/server/command.go
+++ b/server/command.go
@@ -34,6 +34,7 @@ const commandHelp = `* |/gitlab connect| - Connect your Mattermost account to yo
 	* issue_comments - includes new issue comments
 	* merge_request_comments - include new merge-request comments
 	* merge_request_assigns - includes merge request assignment and unassignment notifications
+	* issue_assigns - includes issue assignment and unassignment notifications
 	* pipeline - includes pipeline runs
 	* tag - include tag creation
     * pull_reviews - includes merge request reviews
@@ -1151,7 +1152,7 @@ func (p *Plugin) getAutocompleteData(config *configuration) *model.AutocompleteD
 
 	subscriptionsAdd := model.NewAutocompleteData(commandAdd, "owner[/repo] [features]", "Subscribe the current channel to receive notifications from a project")
 	subscriptionsAdd.AddTextArgument("Project path: includes user or group name with optional slash project name", "owner[/repo]", "")
-	subscriptionsAdd.AddTextArgument("comma-delimited list of features to subscribe to: issues, confidential_issues, merges, pushes, issue_comments, merge_request_comments, merge_request_assigns, pipeline, tag, pull_reviews, label:<labelName>, deployments, releases", "[features] (optional)", `/[^,-\s]+(,[^,-\s]+)*/`)
+	subscriptionsAdd.AddTextArgument("comma-delimited list of features to subscribe to: issues, confidential_issues, merges, pushes, issue_comments, merge_request_comments, merge_request_assigns, issue_assigns, pipeline, tag, pull_reviews, label:<labelName>, deployments, releases", "[features] (optional)", `/[^,-\s]+(,[^,-\s]+)*/`)
 	subscriptions.AddCommand(subscriptionsAdd)
 
 	subscriptionsDelete := model.NewAutocompleteData(commandDelete, "owner[/repo]", "Unsubscribe the current channel from a repository")

--- a/server/subscription/subscription.go
+++ b/server/subscription/subscription.go
@@ -24,6 +24,7 @@ var allFeatures = map[string]bool{
 	"deployments":            true,
 	"releases":               true,
 	"merge_request_assigns":  true,
+	"issue_assigns":          true,
 	// "label:":                 true,//particular case for label:XXX
 }
 
@@ -150,4 +151,8 @@ func (s *Subscription) Deployments() bool {
 
 func (s *Subscription) MergeRequestAssigns() bool {
 	return strings.Contains(s.Features, "merge_request_assigns")
+}
+
+func (s *Subscription) IssueAssigns() bool {
+	return strings.Contains(s.Features, "issue_assigns")
 }

--- a/server/webhook/issue.go
+++ b/server/webhook/issue.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 
 	"github.com/xanzy/go-gitlab"
+
+	"github.com/mattermost/mattermost-plugin-gitlab/server/subscription"
 )
 
 func (w *webhook) HandleIssue(ctx context.Context, event *gitlab.IssueEvent, eventType gitlab.EventType) ([]*HandleWebhook, []string, error) {
@@ -28,6 +30,7 @@ func (w *webhook) handleDMIssue(event *gitlab.IssueEvent) ([]*HandleWebhook, err
 	senderGitlabUsername := event.User.Username
 
 	message := ""
+	handlers := []*HandleWebhook{}
 
 	switch event.ObjectAttributes.Action {
 	case actionOpen:
@@ -38,6 +41,27 @@ func (w *webhook) handleDMIssue(event *gitlab.IssueEvent) ([]*HandleWebhook, err
 		message = fmt.Sprintf("[%s](%s) closed your issue [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Project.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
 	case actionReopen:
 		message = fmt.Sprintf("[%s](%s) reopened your issue [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Project.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL)
+	case actionUpdate:
+		if event.Changes.Assignees.Current != nil || event.Changes.Assignees.Previous != nil {
+			newlyAssigned := w.calculateUserDiffs(event.Changes.Assignees.Previous, event.Changes.Assignees.Current)
+			newlyUnassigned := w.calculateUserDiffs(event.Changes.Assignees.Current, event.Changes.Assignees.Previous)
+
+			if len(newlyAssigned) != 0 {
+				handlers = append(handlers, &HandleWebhook{
+					Message: fmt.Sprintf("[%s](%s) assigned you to issue [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Project.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL),
+					ToUsers: newlyAssigned,
+					From:    senderGitlabUsername,
+				})
+			}
+
+			if len(newlyUnassigned) != 0 {
+				handlers = append(handlers, &HandleWebhook{
+					Message: fmt.Sprintf("[%s](%s) unassigned you from issue [%s#%v](%s)", senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername), event.Project.PathWithNamespace, event.ObjectAttributes.IID, event.ObjectAttributes.URL),
+					ToUsers: newlyUnassigned,
+					From:    senderGitlabUsername,
+				})
+			}
+		}
 	}
 
 	if message != "" {
@@ -49,12 +73,14 @@ func (w *webhook) handleDMIssue(event *gitlab.IssueEvent) ([]*HandleWebhook, err
 		}
 		toUsers = append(toUsers, authorGitlabUsername)
 
-		handlers := []*HandleWebhook{{
+		handlers = append(handlers, &HandleWebhook{
 			Message: message,
 			ToUsers: toUsers,
 			From:    senderGitlabUsername,
-		}}
+		})
+	}
 
+	if len(handlers) > 0 {
 		if mention := w.handleMention(mentionDetails{
 			senderUsername:    senderGitlabUsername,
 			pathWithNamespace: event.Project.PathWithNamespace,
@@ -76,6 +102,7 @@ func (w *webhook) handleChannelIssue(ctx context.Context, event *gitlab.IssueEve
 	res := []*HandleWebhook{}
 
 	message := ""
+	var assignMessages []string
 	var warnings []string
 
 	switch issue.Action {
@@ -89,39 +116,49 @@ func (w *webhook) handleChannelIssue(ctx context.Context, event *gitlab.IssueEve
 		if len(event.Changes.Labels.Current) > 0 && !sameLabels(event.Changes.Labels.Current, event.Changes.Labels.Previous) {
 			message = fmt.Sprintf("#### %s\n##### [%s#%v](%s)\n###### issue labeled `%s` by [%s](%s) on [%s](%s)\n\n%s", issue.Title, repo.PathWithNamespace, issue.IID, issue.URL, labelToString(event.Changes.Labels.Current), event.User.Username, w.gitlabRetreiver.GetUserURL(event.User.Username), issue.UpdatedAt, issue.URL, sanitizeDescription(issue.Description))
 		}
+
+		if event.Changes.Assignees.Current != nil || event.Changes.Assignees.Previous != nil {
+			newlyAssigned := w.calculateUserDiffs(event.Changes.Assignees.Previous, event.Changes.Assignees.Current)
+			newlyUnassigned := w.calculateUserDiffs(event.Changes.Assignees.Current, event.Changes.Assignees.Previous)
+
+			for _, username := range newlyAssigned {
+				assignMessages = append(assignMessages, fmt.Sprintf("[%s](%s) Issue [%s](%s) was assigned to [%s](%s) by [%s](%s)",
+					repo.PathWithNamespace, repo.WebURL, issue.Title, issue.URL,
+					username, w.gitlabRetreiver.GetUserURL(username),
+					senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername)))
+			}
+			for _, username := range newlyUnassigned {
+				assignMessages = append(assignMessages, fmt.Sprintf("[%s](%s) Issue [%s](%s) was unassigned from [%s](%s) by [%s](%s)",
+					repo.PathWithNamespace, repo.WebURL, issue.Title, issue.URL,
+					username, w.gitlabRetreiver.GetUserURL(username),
+					senderGitlabUsername, w.gitlabRetreiver.GetUserURL(senderGitlabUsername)))
+			}
+		}
 	}
 
+	if len(message) == 0 && len(assignMessages) == 0 {
+		return res, warnings, nil
+	}
+
+	// Trust the payload's confidential flag in addition to the event type, so a
+	// confidential issue delivered under the regular Issue Hook is still gated.
+	isConfidential := issue.Confidential || eventType == gitlab.EventConfidentialIssue
+	confidentialAllowed := func(sub *subscription.Subscription) bool {
+		return !isConfidential || sub.ConfidentialIssues()
+	}
+
+	namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
+	subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
+		ctx, namespace, project,
+		repo.Visibility == gitlab.PublicVisibility,
+		isConfidential,
+	)
+
 	if len(message) > 0 {
-		// Trust the payload's confidential flag in addition to the event type, so a
-		// confidential issue delivered under the regular Issue Hook is still gated.
-		isConfidential := issue.Confidential || eventType == gitlab.EventConfidentialIssue
-
-		toChannels := make([]string, 0)
-		namespace, project := normalizeNamespacedProject(repo.PathWithNamespace)
-		subs := w.gitlabRetreiver.GetSubscribedChannelsForProject(
-			ctx, namespace, project,
-			repo.Visibility == gitlab.PublicVisibility,
-			isConfidential,
-		)
-		for _, sub := range subs {
-			if !sub.Issues() {
-				continue
-			}
-
-			if isConfidential && !sub.ConfidentialIssues() {
-				continue
-			}
-
-			labels, err := sub.Labels()
-			if err != nil {
-				warnings = append(warnings, err.Error())
-			} else if len(labels) > 0 && !containsAnyLabel(event.Labels, labels) {
-				continue
-			}
-
-			toChannels = append(toChannels, sub.ChannelID)
-		}
-
+		toChannels, ws := filterChannelsByFeature(subs, event.Labels, func(sub *subscription.Subscription) bool {
+			return sub.Issues() && confidentialAllowed(sub)
+		})
+		warnings = append(warnings, ws...)
 		if len(toChannels) > 0 {
 			res = append(res, &HandleWebhook{
 				From:       senderGitlabUsername,
@@ -131,5 +168,23 @@ func (w *webhook) handleChannelIssue(ctx context.Context, event *gitlab.IssueEve
 			})
 		}
 	}
+
+	if len(assignMessages) > 0 {
+		toChannels, ws := filterChannelsByFeature(subs, event.Labels, func(sub *subscription.Subscription) bool {
+			return (sub.Issues() || sub.IssueAssigns()) && confidentialAllowed(sub)
+		})
+		warnings = append(warnings, ws...)
+		if len(toChannels) > 0 {
+			for _, msg := range assignMessages {
+				res = append(res, &HandleWebhook{
+					From:       senderGitlabUsername,
+					Message:    msg,
+					ToUsers:    []string{},
+					ToChannels: toChannels,
+				})
+			}
+		}
+	}
+
 	return res, warnings, nil
 }

--- a/server/webhook/issue.go
+++ b/server/webhook/issue.go
@@ -78,9 +78,9 @@ func (w *webhook) handleDMIssue(event *gitlab.IssueEvent) ([]*HandleWebhook, err
 			ToUsers: toUsers,
 			From:    senderGitlabUsername,
 		})
-	}
 
-	if len(handlers) > 0 {
+		// Only parse mentions for actions that change the description, otherwise
+		// every assignee update would re-notify everyone mentioned in the issue.
 		if mention := w.handleMention(mentionDetails{
 			senderUsername:    senderGitlabUsername,
 			pathWithNamespace: event.Project.PathWithNamespace,
@@ -90,9 +90,9 @@ func (w *webhook) handleDMIssue(event *gitlab.IssueEvent) ([]*HandleWebhook, err
 		}); mention != nil {
 			handlers = append(handlers, mention)
 		}
-		return handlers, nil
 	}
-	return []*HandleWebhook{}, nil
+
+	return handlers, nil
 }
 
 func (w *webhook) handleChannelIssue(ctx context.Context, event *gitlab.IssueEvent, eventType gitlab.EventType) ([]*HandleWebhook, []string, error) {
@@ -158,7 +158,7 @@ func (w *webhook) handleChannelIssue(ctx context.Context, event *gitlab.IssueEve
 		toChannels, ws := filterChannelsByFeature(subs, event.Labels, func(sub *subscription.Subscription) bool {
 			return sub.Issues() && confidentialAllowed(sub)
 		})
-		warnings = append(warnings, ws...)
+		warnings = appendUniqueWarnings(warnings, ws...)
 		if len(toChannels) > 0 {
 			res = append(res, &HandleWebhook{
 				From:       senderGitlabUsername,
@@ -173,7 +173,7 @@ func (w *webhook) handleChannelIssue(ctx context.Context, event *gitlab.IssueEve
 		toChannels, ws := filterChannelsByFeature(subs, event.Labels, func(sub *subscription.Subscription) bool {
 			return (sub.Issues() || sub.IssueAssigns()) && confidentialAllowed(sub)
 		})
-		warnings = append(warnings, ws...)
+		warnings = appendUniqueWarnings(warnings, ws...)
 		if len(toChannels) > 0 {
 			for _, msg := range assignMessages {
 				res = append(res, &HandleWebhook{

--- a/server/webhook/issue_fixture_test.go
+++ b/server/webhook/issue_fixture_test.go
@@ -536,3 +536,132 @@ const ReopenIssue = `{
 													"avatar_url":"https://www.gravatar.com/avatar/c6b552a4cd47f7cf1701ea5b650cd2e3?s=80\\u0026d=identicon"
 													}]
 													}`
+
+const AssignIssue = `{
+	"object_kind":"issue",
+	"event_type":"issue",
+	"user":{
+		"name":"Administrator",
+		"username":"root",
+		"avatar_url":"https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon"
+	},
+	"project":{
+		"id":24,
+		"name":"webhook",
+		"description":"",
+		"web_url":"http://localhost:3000/manland/webhook",
+		"namespace":"manland",
+		"visibility_level":20,
+		"path_with_namespace":"manland/webhook",
+		"homepage":"http://localhost:3000/manland/webhook",
+		"url":"ssh://rmaneschi@localhost:2222/manland/webhook.git",
+		"ssh_url":"ssh://rmaneschi@localhost:2222/manland/webhook.git",
+		"http_url":"http://localhost:3000/manland/webhook.git"
+	},
+	"object_attributes":{
+		"author_id":1,
+		"confidential":false,
+		"created_at":"2019-04-06 21:03:04 UTC",
+		"description":"hello world!",
+		"id":181,
+		"iid":1,
+		"state":"opened",
+		"title":"test new issue",
+		"updated_at":"2019-04-06 21:08:00 UTC",
+		"url":"http://localhost:3000/manland/webhook/issues/1",
+		"assignee_ids":[50],
+		"assignee_id":50,
+		"action":"update"
+	},
+	"labels":[],
+	"changes":{
+		"assignees":{
+			"previous":[
+				{
+					"id": 100,
+					"name": "user",
+					"username": "user",
+					"avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon"
+				}
+			],
+			"current":[
+				{
+					"id": 50,
+					"name": "manland",
+					"username": "manland",
+					"avatar_url": "https://www.gravatar.com/avatar/c6b552a4cd47f7cf1701ea5b650cd2e3?s=80\u0026d=identicon"
+				}
+			]
+		}
+	},
+	"repository":{
+		"name":"webhook",
+		"url":"ssh://rmaneschi@localhost:2222/manland/webhook.git",
+		"description":"",
+		"homepage":"http://localhost:3000/manland/webhook"
+	},
+	"assignees":[{
+		"name":"manland",
+		"username":"manland",
+		"avatar_url":"https://www.gravatar.com/avatar/c6b552a4cd47f7cf1701ea5b650cd2e3?s=80\u0026d=identicon"
+	}]
+}`
+
+const UnassignIssue = `{
+	"object_kind":"issue",
+	"event_type":"issue",
+	"user":{
+		"name":"Administrator",
+		"username":"root",
+		"avatar_url":"https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon"
+	},
+	"project":{
+		"id":24,
+		"name":"webhook",
+		"description":"",
+		"web_url":"http://localhost:3000/manland/webhook",
+		"namespace":"manland",
+		"visibility_level":20,
+		"path_with_namespace":"manland/webhook",
+		"homepage":"http://localhost:3000/manland/webhook",
+		"url":"ssh://rmaneschi@localhost:2222/manland/webhook.git",
+		"ssh_url":"ssh://rmaneschi@localhost:2222/manland/webhook.git",
+		"http_url":"http://localhost:3000/manland/webhook.git"
+	},
+	"object_attributes":{
+		"author_id":1,
+		"confidential":false,
+		"created_at":"2019-04-06 21:03:04 UTC",
+		"description":"hello world!",
+		"id":181,
+		"iid":1,
+		"state":"opened",
+		"title":"test new issue",
+		"updated_at":"2019-04-06 21:08:00 UTC",
+		"url":"http://localhost:3000/manland/webhook/issues/1",
+		"assignee_ids":[],
+		"assignee_id":null,
+		"action":"update"
+	},
+	"labels":[],
+	"changes":{
+		"assignees":{
+			"previous":[
+				{
+					"id": 50,
+					"name": "manland",
+					"username": "manland",
+					"avatar_url": "https://www.gravatar.com/avatar/c6b552a4cd47f7cf1701ea5b650cd2e3?s=80\u0026d=identicon"
+				}
+			],
+			"current":[]
+		}
+	},
+	"repository":{
+		"name":"webhook",
+		"url":"ssh://rmaneschi@localhost:2222/manland/webhook.git",
+		"description":"",
+		"homepage":"http://localhost:3000/manland/webhook"
+	},
+	"assignees":[]
+}`

--- a/server/webhook/issue_test.go
+++ b/server/webhook/issue_test.go
@@ -274,6 +274,7 @@ func TestIssueWebhook(t *testing.T) {
 			for index := range res {
 				assert.Equal(t, test.res[index].Message, res[index].Message)
 				assert.EqualValues(t, test.res[index].ToUsers, res[index].ToUsers)
+				assert.ElementsMatch(t, test.res[index].ToChannels, res[index].ToChannels)
 				assert.Equal(t, test.res[index].From, res[index].From)
 			}
 		})
@@ -396,6 +397,69 @@ func TestConfidentialIssueUnderRegularEventTypeIsGated(t *testing.T) {
 		assert.Empty(t, handler.ToChannels,
 			"confidential issue must not reach a channel lacking the confidential_issues feature")
 	}
+}
+
+// Mentions are parsed from the issue description, which an assignee update does
+// not touch, so reassigning must not re-notify everyone mentioned in it.
+func TestIssueAssignDoesNotRepeatDescriptionMentions(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		testTitle     string
+		fixture       string
+		expectMention bool
+	}{
+		{
+			testTitle:     "new issue notifies mentioned users",
+			fixture:       NewIssue,
+			expectMention: true,
+		},
+		{
+			testTitle:     "assignee update does not notify mentioned users",
+			fixture:       AssignIssue,
+			expectMention: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.testTitle, func(t *testing.T) {
+			retreiver := newFakeWebhook([]*subscription.Subscription{})
+			retreiver.mentionedUsernames = []string{"user2"}
+			w := NewWebhook(retreiver)
+			issueEvent := &gitlab.IssueEvent{}
+			require.NoError(t, json.Unmarshal([]byte(test.fixture), issueEvent))
+
+			res, _, err := w.HandleIssue(context.Background(), issueEvent, gitlab.EventTypeIssue)
+			require.NoError(t, err)
+
+			mentioned := false
+			for _, handler := range res {
+				if strings.Contains(handler.Message, "mentioned you on") {
+					mentioned = true
+				}
+			}
+			assert.Equal(t, test.expectMention, mentioned)
+		})
+	}
+}
+
+// A single update can change labels and assignees at once, which runs the
+// channel filter twice over the same subscriptions.
+func TestIssueUpdateWithLabelAndAssigneeChangeWarnsOnce(t *testing.T) {
+	t.Parallel()
+	fixture := strings.ReplaceAll(AssignIssue, `"changes":{`,
+		`"changes":{"labels":{"previous":[],"current":[{"id":1,"title":"bug"}]},`)
+
+	retreiver := newFakeWebhook([]*subscription.Subscription{
+		{ChannelID: "channel1", CreatorID: "1", Features: "issues,label:1", Repository: "manland/webhook"},
+	})
+	w := NewWebhook(retreiver)
+	issueEvent := &gitlab.IssueEvent{}
+	require.NoError(t, json.Unmarshal([]byte(fixture), issueEvent))
+
+	_, warnings, err := w.HandleIssue(context.Background(), issueEvent, gitlab.EventTypeIssue)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{`each label must be wrapped in quotes, e.g. label:"bug"`}, warnings)
 }
 
 func TestConfidentialIssueAssignIsGated(t *testing.T) {

--- a/server/webhook/issue_test.go
+++ b/server/webhook/issue_test.go
@@ -115,6 +115,130 @@ var testDataIssue = []testDataIssueStr{
 		warnings: []string{},
 	},
 	{
+		testTitle:       "root assign manland to issue (DM only, no channel subscription)",
+		fixture:         AssignIssue,
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{}),
+		res: []*HandleWebhook{
+			{
+				Message:    "[root](http://my.gitlab.com/root) assigned you to issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"manland"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+			{
+				Message:    "[root](http://my.gitlab.com/root) unassigned you from issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"user"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+		},
+		warnings: []string{},
+	},
+	{
+		testTitle:       "root unassign manland from issue (DM only)",
+		fixture:         UnassignIssue,
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{}),
+		res: []*HandleWebhook{
+			{
+				Message:    "[root](http://my.gitlab.com/root) unassigned you from issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"manland"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+		},
+		warnings: []string{},
+	},
+	{
+		testTitle: "root assign manland to issue and display in channel1 with issues subscription",
+		fixture:   AssignIssue,
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "issues", Repository: "manland/webhook"},
+		}),
+		res: []*HandleWebhook{
+			{
+				Message:    "[root](http://my.gitlab.com/root) assigned you to issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"manland"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+			{
+				Message:    "[root](http://my.gitlab.com/root) unassigned you from issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"user"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+			{
+				Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Issue [test new issue](http://localhost:3000/manland/webhook/issues/1) was assigned to [manland](http://my.gitlab.com/manland) by [root](http://my.gitlab.com/root)",
+				ToUsers:    []string{},
+				ToChannels: []string{"channel1"},
+				From:       "root",
+			},
+			{
+				Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Issue [test new issue](http://localhost:3000/manland/webhook/issues/1) was unassigned from [user](http://my.gitlab.com/user) by [root](http://my.gitlab.com/root)",
+				ToUsers:    []string{},
+				ToChannels: []string{"channel1"},
+				From:       "root",
+			},
+		},
+		warnings: []string{},
+	},
+	{
+		testTitle: "root assign manland to issue and display in channel1 with issue_assigns subscription",
+		fixture:   AssignIssue,
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "issue_assigns", Repository: "manland/webhook"},
+		}),
+		res: []*HandleWebhook{
+			{
+				Message:    "[root](http://my.gitlab.com/root) assigned you to issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"manland"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+			{
+				Message:    "[root](http://my.gitlab.com/root) unassigned you from issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"user"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+			{
+				Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Issue [test new issue](http://localhost:3000/manland/webhook/issues/1) was assigned to [manland](http://my.gitlab.com/manland) by [root](http://my.gitlab.com/root)",
+				ToUsers:    []string{},
+				ToChannels: []string{"channel1"},
+				From:       "root",
+			},
+			{
+				Message:    "[manland/webhook](http://localhost:3000/manland/webhook) Issue [test new issue](http://localhost:3000/manland/webhook/issues/1) was unassigned from [user](http://my.gitlab.com/user) by [root](http://my.gitlab.com/root)",
+				ToUsers:    []string{},
+				ToChannels: []string{"channel1"},
+				From:       "root",
+			},
+		},
+		warnings: []string{},
+	},
+	{
+		testTitle: "root assign manland to issue but no channel notification without matching subscription",
+		fixture:   AssignIssue,
+		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
+			{ChannelID: "channel1", CreatorID: "1", Features: "merges", Repository: "manland/webhook"},
+		}),
+		res: []*HandleWebhook{
+			{
+				Message:    "[root](http://my.gitlab.com/root) assigned you to issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"manland"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+			{
+				Message:    "[root](http://my.gitlab.com/root) unassigned you from issue [manland/webhook#1](http://localhost:3000/manland/webhook/issues/1)",
+				ToUsers:    []string{"user"},
+				ToChannels: []string{},
+				From:       "root",
+			},
+		},
+		warnings: []string{},
+	},
+	{
 		testTitle: "manland reopen issue of root and display in channel with subscription label warning",
 		fixture:   ReopenIssue,
 		gitlabRetreiver: newFakeWebhook([]*subscription.Subscription{
@@ -271,5 +395,50 @@ func TestConfidentialIssueUnderRegularEventTypeIsGated(t *testing.T) {
 	for _, handler := range res {
 		assert.Empty(t, handler.ToChannels,
 			"confidential issue must not reach a channel lacking the confidential_issues feature")
+	}
+}
+
+func TestConfidentialIssueAssignIsGated(t *testing.T) {
+	t.Parallel()
+	confidentialAssign := strings.ReplaceAll(AssignIssue, `"confidential":false`, `"confidential":true`)
+
+	testCases := []struct {
+		testTitle           string
+		features            string
+		expectChannelNotify bool
+	}{
+		{
+			testTitle:           "issue_assigns without confidential_issues is gated",
+			features:            "issue_assigns",
+			expectChannelNotify: false,
+		},
+		{
+			testTitle:           "issue_assigns with confidential_issues notifies the channel",
+			features:            "issue_assigns,confidential_issues",
+			expectChannelNotify: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.testTitle, func(t *testing.T) {
+			retreiver := newFakeWebhook([]*subscription.Subscription{
+				{ChannelID: "channel1", CreatorID: "1", Features: test.features, Repository: "manland/webhook"},
+			})
+			w := NewWebhook(retreiver)
+			issueEvent := &gitlab.IssueEvent{}
+			require.NoError(t, json.Unmarshal([]byte(confidentialAssign), issueEvent))
+
+			res, _, err := w.HandleIssue(context.Background(), issueEvent, gitlab.EventTypeIssue)
+			require.NoError(t, err)
+			assert.True(t, retreiver.gotIsConfidential)
+
+			notified := false
+			for _, handler := range res {
+				if len(handler.ToChannels) > 0 {
+					notified = true
+				}
+			}
+			assert.Equal(t, test.expectChannelNotify, notified)
+		})
 	}
 }

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -171,6 +172,17 @@ func filterChannelsByFeature(
 		channels = append(channels, sub.ChannelID)
 	}
 	return channels, warnings
+}
+
+// appendUniqueWarnings keeps warnings distinct, so a subscription inspected by
+// more than one feature filter for the same event only reports a problem once.
+func appendUniqueWarnings(warnings []string, newWarnings ...string) []string {
+	for _, warning := range newWarnings {
+		if !slices.Contains(warnings, warning) {
+			warnings = append(warnings, warning)
+		}
+	}
+	return warnings
 }
 
 func anyEventLabelInSubs(sub *subscription.Subscription, eventLabels []*gitlab.EventLabel) (bool, string) {

--- a/server/webhook/webhook_test.go
+++ b/server/webhook/webhook_test.go
@@ -16,6 +16,10 @@ import (
 type fakeWebhook struct {
 	subs []*subscription.Subscription
 
+	// mentionedUsernames is returned for every parsed body, letting tests drive
+	// the mention handling path.
+	mentionedUsernames []string
+
 	// gotIsConfidential records the confidentiality flag of the last lookup so
 	// tests can assert that confidential events reach the authorization check.
 	gotIsConfidential bool
@@ -52,8 +56,8 @@ func (*fakeWebhook) GetUsernameByID(id int) string {
 	}
 }
 
-func (*fakeWebhook) ParseGitlabUsernamesFromText(body string) []string {
-	return []string{}
+func (f *fakeWebhook) ParseGitlabUsernamesFromText(body string) []string {
+	return f.mentionedUsernames
 }
 
 func (f *fakeWebhook) GetSubscribedChannelsForProject(ctx context.Context, namespace, project string, isPublicVisibility, isConfidential bool) []*subscription.Subscription {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds support to issue assigned events in channel subscriptions

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-67255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The change spans subscription validation and webhook delivery paths. It changes user-facing notification behavior and adds a new subscription contract.

**Regression Risk:** Existing issue update handling and channel filtering could regress. Tests cover assignment, unassignment, subscription matching, and confidential issue gating.

**QA Recommendation:** Perform focused manual QA for issue assignment and unassignment events across DM and channel subscriptions. Skipping manual QA carries moderate risk.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->