### PR TITLE
MM-70684 Update GitLab plugin for React 19 in Mattermost v12

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-gitlab",
     "support_url": "https://github.com/mattermost/mattermost-plugin-gitlab/issues",
     "icon_path": "assets/icon.svg",
-    "min_server_version": "10.7.0",
+    "min_server_version": "12.0.0",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "build": "webpack --mode=production",
         "build:watch": "webpack --mode=production --watch",
-        "debug": "webpack --mode=none",
+        "debug": "webpack --mode=development",
         "debug:watch": "webpack --mode=development --watch",
         "lint": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet --cache",
         "fix": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet --fix --cache",

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -45,6 +45,9 @@ module.exports = {
     externals: {
         react: 'React',
         'react-dom': 'ReactDOM',
+        'react-dom/client': 'ReactDOM',
+        'react/jsx-runtime': 'ReactJSXRuntime',
+        'react/jsx-dev-runtime': 'ReactJSXDevRuntime',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',


### PR DESCRIPTION
#### Summary

Fixes the GitLab plugin startup crash on Mattermost v12 / React 19. Although React was already supplied by the host, the plugin bundled React 18's JSX runtime, which accesses removed React internals such as `ReactCurrentOwner`. Resolving JSX runtime imports to the host keeps React and JSX helpers aligned.

Externalizes `react-dom/client`, `react/jsx-runtime`, and `react/jsx-dev-runtime` to the host globals and requires Mattermost 12.0.0. Requires the host JSX runtime exports from https://github.com/mattermost/mattermost/pull/38489. Also changes the debug build to development mode.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-70684

#### Release Note

```release-note
Updated the GitLab plugin for React 19 in Mattermost v12 and fixed a startup crash caused by an older JSX runtime. Raised the minimum supported Mattermost version to 12.0.0.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The changes are isolated to the GitLab plugin but affect startup behavior and React runtime compatibility. The minimum Mattermost version also changes from `10.7.0` to `12.0.0`.

**Regression Risk:** Incorrect host global mappings could cause runtime or startup failures. The affected paths require validation with Mattermost 12.

**QA Recommendation:** Perform manual QA in Mattermost 12 for plugin startup, webapp loading, and core GitLab plugin flows. Skipping manual QA has moderate risk.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->